### PR TITLE
Prepare repo for renaming from cur --> tenejo

### DIFF
--- a/app/lib/virus_scanner.rb
+++ b/app/lib/virus_scanner.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 require 'clamby/error'
-module Cur
+module Tenejo
   ##
   # A Clamby based virus scanner
   #

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -2,7 +2,7 @@
   <div class="container-fluid">
     <div class="navbar-text text-left">
       <span> &copy; <%= Date.today.year %> Data Curation Experts, LLC </span>
-      <br> CuriTeca
+      <br> Tenejo
       <div class="version">
         ENV: <%= Rails.env %>
         <br>SHA: <%= GIT_SHA %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -9,7 +9,7 @@ require 'deprecation'
 Deprecation.default_deprecation_behavior = :silence
 Bundler.require(*Rails.groups)
 
-module Cur
+module Tenejo
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2

--- a/config/browse_everything_providers.yml
+++ b/config/browse_everything_providers.yml
@@ -3,7 +3,7 @@
 # The file_system provider can be a path to any directory on the server where your application is running.
 #
 file_system:
-  home: /home/mml/cur
+  home: /home/mml/tenejo
 # dropbox:
 #   client_id: YOUR_DROPBOX_APP_KEY
 #   client_secret: YOUR_DROPBOX_APP_SECRET

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -6,4 +6,4 @@ test:
 
 production:
   adapter: postgresql
-  channel_prefix: cur_production
+  channel_prefix: tenejo_production

--- a/config/database.yml
+++ b/config/database.yml
@@ -10,14 +10,14 @@ default: &default
 
 development:
   <<: *default
-  database: cur_development
+  database: tenejo_development
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: <%= ENV["CI"] == true ? "circle_test" : "cur_test" %>
+  database: <%= ENV["CI"] == true ? "circle_test" : "tenejo_test" %>
 
 production:
   <<: *default

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -3,11 +3,11 @@
 lock "~> 3.16.0"
 
 require 'capistrano/passenger'
-set :application, "cur"
-set :repo_url, "git@github.com:curationexperts/cur.git"
-set :ssh_options, keys: ["cur-cd"] if File.exist?("cur-cd")
+set :application, "tenejo"
+set :repo_url, 'https://github.com/curationexperts/tenejo'
+set :ssh_options, keys: ["tenejo-cd"] if File.exist?("tenejo-cd")
 
-set :deploy_to, '/opt/cur'
+set :deploy_to, '/opt/tenejo'
 set :rails_env, 'production'
 set :log_level, :warn
 set :bundle_env_variables, nokogiri_use_system_libraries: 1

--- a/config/deploy/localhost.rb
+++ b/config/deploy/localhost.rb
@@ -1,3 +1,2 @@
 # frozen_string_literal: true
-set :repo_url, 'https://github.com/curationexperts/cur'
 server '127.0.0.1', user: 'deploy', roles: [:web, :app, :db]

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -62,7 +62,7 @@ Rails.application.configure do
 
   # Use a real queuing backend for Active Job (and separate queues per environment)
   # config.active_job.queue_adapter     = :resque
-  # config.active_job.queue_name_prefix = "cur_#{Rails.env}"
+  # config.active_job.queue_name_prefix = "tenejo_#{Rails.env}"
 
   config.action_mailer.perform_caching = false
   config.action_mailer.perform_deliveries = true

--- a/lib/tasks/tenejo.rake
+++ b/lib/tasks/tenejo.rake
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 CHARS = ('0'..'9').to_a + ('A'..'Z').to_a + ('a'..'z').to_a
-namespace :cur do
+namespace :tenejo do
   desc 'Create  user'
   task :create_user, [:email] => :environment do |_t, args|
     pw = random_password

--- a/spec/virus_scanner_spec.rb
+++ b/spec/virus_scanner_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require './app/lib/virus_scanner'
 
-RSpec.describe Cur::VirusScanner do
+RSpec.describe Tenejo::VirusScanner do
   context "with clean file" do
     let(:goodfile) { './spec/fixtures/images/cat.jpg' }
     it "does not freak out" do


### PR DESCRIPTION
This commit updates relevant referecances from `cur` to `tenejo` in
anticipation of renaming the repository of github.