### PR TITLE
Allow inspection of the collection model to figure out metadata

### DIFF
--- a/app/lib/tenejo/preflight.rb
+++ b/app/lib/tenejo/preflight.rb
@@ -2,6 +2,7 @@
 require 'csv'
 require 'active_model'
 require 'active_support/core_ext/enumerable'
+
 module Tenejo
   class PreFlightObj
     include ActiveModel::Validations
@@ -54,6 +55,7 @@ module Tenejo
                   :visibility, :license, :parent, :resource_type, :abstract_or_summary, :contributor, :publisher].freeze
     REQUIRED_FIELDS = [:title, :identifier, :deduplication_key, :creator, :keyword, :visibility].freeze
     attr_accessor(*ALL_FIELDS)
+    attr_accessor(*::Collection.terms)
     validates_presence_of(*REQUIRED_FIELDS)
   end
 

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -6,4 +6,16 @@ class Collection < ActiveFedora::Base
   # You can replace these metadata if they're not suitable
   include Hyrax::BasicMetadata
   self.indexer = Hyrax::CollectionWithBasicMetadataIndexer
+
+  def self.terms
+    @metadata ||= properties.keys.map(&:to_sym)
+  end
+
+  def self.required_terms
+    @required_metadata ||= Hyrax::Forms::CollectionForm.required_fields
+  end
+
+  def self.editable_terms
+    @editable_metadata ||= Hyrax::Forms::CollectionForm.terms
+  end
 end

--- a/spec/lib/tenejo/preflight_spec.rb
+++ b/spec/lib/tenejo/preflight_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
-require './app/lib/tenejo/preflight'
-require 'spec_helper'
+require 'rails_helper'
 require 'fileutils'
-require 'byebug'
 
 RSpec.describe Tenejo::Preflight do
   before :all do

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Collection do
+  it '::metadata returns all fields' do
+    expect(described_class.terms).to include(:description)
+    expect(described_class.terms).not_to include(:fuel_injector_count)
+  end
+
+  it '::required_metadata returns required fields' do
+    expect(described_class.required_terms).to include(:title)
+    expect(described_class.required_terms).not_to include(:description)
+  end
+
+  it '::editable_metadata lists user editable fields' do
+    expect(described_class.editable_terms).to include(:creator)
+    expect(described_class.editable_terms).not_to include(:date_uploaded)
+  end
+end


### PR DESCRIPTION
This change adds three class methods to get the list of
* `::terms` - returns all avaialable metadata fields
* `::required_terms` - returns fields markes as "required" on the edit form
* `::editable_terms` - returns all fields users can edit on the form