### PR TITLE
Add temporary UI to allow preflight testing

### DIFF
--- a/app/controllers/tenejo/preflight_controller.rb
+++ b/app/controllers/tenejo/preflight_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+class Tenejo::PreflightController < ApplicationController
+  def new
+  end
+
+  def show
+    @original_file = session[:source_file]
+    @manifest = session[:manifest]
+    @preflight_graph = Tenejo::Preflight.read_csv(@manifest, 'tmp/uploads')
+    File.delete(@manifest)
+    @errors = @preflight_graph[:fatal_errors]
+    @warnings = @preflight_graph[:warnings]
+    @collections = @preflight_graph[:collection]
+    @works = @preflight_graph[:work]
+    @files = @preflight_graph[:file]
+  end
+
+  def upload
+    uploaded_io = params[:manifest]
+    manifest = Tempfile.open(['manifest', '.csv'], Rails.root.join('tmp', 'uploads'))
+    manifest.write(uploaded_io.read)
+    manifest.close
+    session[:source_file] = uploaded_io.original_filename
+    session[:manifest] = manifest.path
+    redirect_to tenejo_preflight_show_path
+  end
+end

--- a/app/views/hyrax/dashboard/sidebar/_tasks.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_tasks.html.erb
@@ -8,3 +8,7 @@
     <span class="fa fa-id-card" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.manage_roles') %></span>
   <% end %>
 <% end %>
+<%= menu.nav_link('/tenejo/preflight/new',
+                  onclick: "dontChangeAccordion(event);") do %>
+  <span class="fa fa-paper-plane" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('tenejo.admin.sidebar.preflight') %></span>
+<% end %>

--- a/app/views/tenejo/preflight/new.html.erb
+++ b/app/views/tenejo/preflight/new.html.erb
@@ -1,0 +1,9 @@
+<h1>Tenejo::Preflight#new</h1>
+<p>Find me in app/views/tenejo/preflight/new.html.erb</p>
+upload a file ...
+
+<%= form_tag({:action => :upload}, :multipart => true) do %>
+  <%= file_field_tag 'manifest' %>
+  <br/>
+  <%= submit_tag("Preview Import", class: 'btn-primary btn-lg') %>
+<% end %>

--- a/app/views/tenejo/preflight/show.html.erb
+++ b/app/views/tenejo/preflight/show.html.erb
@@ -1,0 +1,133 @@
+<h1>PREFLIGHT</h1>  <%= link_to 'Do Another', tenejo_preflight_new_path, class: 'btn btn-primary btn-large' %>
+
+<h2>File</h2>
+<h4><%= @original_file %></h4>
+<br/>
+
+<h2>Analysis</h2>
+<% unless @errors.blank? %>
+  <div class="well well-sm">
+    <h4 class="bg-danger"">Errors</h4>
+    <ul>
+      <% @errors.each do |error| %>
+        <li><%= error %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
+
+<% unless @warnings.blank? %>
+  <div class="well well-sm">
+    <h4 class="bg-warning">Warnings</h4>
+    <ul>
+      <% @warnings.each do |warning| %>
+        <li><%= warning %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
+
+<% unless @collections.blank? %>
+  <div class="well well-sm">
+    <h4 class="bg-info">Collections</h4>
+    <table>
+      <colgroup>
+        <col style="width: 5rem;">
+        <col style="width: 10rem;">
+        <col style="width: 15rem;">
+        <col>
+      </colgroup>
+      <thead><tr>
+        <th>Row</th>
+        <th>Visibility</th>
+        <th>Identifier</th>
+        <th>Title</th>
+      </tr></thead>
+      <tbody>
+        <% @collections.each do |item| %>
+          <tr>
+            <td><%= item.lineno %></td>
+            <td><%= item.visibility %></td>
+            <td><%= item.identifier %></td>
+            <td><%= item.title %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+<% end %>
+
+<% unless @works.blank? %>
+  <div class="well well-sm">
+    <h4 class="bg-info">Works</h4>
+    <table>
+      <colgroup>
+        <col style="width: 5rem;">
+        <col style="width: 10rem;">
+        <col style="width: 15rem;">
+        <col>
+      </colgroup>
+      <thead><tr>
+        <th>Row</th>
+        <th>Visibility</th>
+        <th>Identifier</th>
+        <th>Title</th>
+      </tr></thead>
+      <tbody>
+      <% @works.each do |item| %>
+        <tr>
+          <td><%= item.lineno %></td>
+          <td><%= item.visibility %></td>
+          <td><%= item.identifier %></td>
+          <td><%= item.title %></td>
+        </tr>
+      <% end %>
+      </tbody>
+    </table>
+  </div>
+<% end %>
+
+<% unless @files.blank? %>
+  <div class="well well-sm">
+    <h4 class="bg-info">Files</h4>
+    <table>
+      <colgroup>
+        <col style="width: 5rem;">
+        <col style="width: 10rem;">
+        <col style="width: 15rem;">
+        <col>
+      </colgroup>
+      <thead><tr>
+        <th>Row</th>
+        <th>Parent</th>
+        <th>Path</th>
+        <th>file</th>
+      </tr></thead>
+      <tbody>
+      <% @files.each do |item| %>
+        <tr>
+          <td><%= item.lineno %></td>
+          <td><%= item.parent %></td>
+          <td><%= item.import_path %></td>
+          <td><%= item.file %></td>
+        </tr>
+      <% end %>
+      </tbody>
+    </table>
+  </div>
+<% end %>
+
+
+<p>
+  <button class="btn btn-primary" type="button" data-toggle="collapse" data-target="#rawPreflight" aria-expanded="false" aria-controls="rawPreflight">
+    Show raw preflight
+  </button>
+</p>
+<div class="collapse" id="rawPreflight">
+  <div class="card card-body">
+    <p><%= @preflight_graph %></p>
+  </div>
+</div>
+
+<%# put a space at the bottom of the page because the footer was overlapping the bottom content %>
+<p style="margin-bottom: 6em">&nbsp;</p>

--- a/config/locales/tenejo.en.yml
+++ b/config/locales/tenejo.en.yml
@@ -1,0 +1,6 @@
+---
+en:
+  tenejo:
+    admin:
+      sidebar:
+        preflight: Preflight

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 require 'sidekiq/web'
 Rails.application.routes.draw do
+  namespace :tenejo do
+    get 'preflight/new'
+    get 'preflight/show'
+    post 'preflight/upload'
+  end
+
   mount Riiif::Engine => 'images', as: :riiif if Hyrax.config.iiif_image_server?
   mount BrowseEverything::Engine => '/browse'
 


### PR DESCRIPTION
This is temporary scaffolding (throw-away code) to give the team
a quick-and-dirty UI to begin testing preflight validations.

This PR should be reverted once we have a working job status
dashboard in place.