### PR TITLE
Update the fedora version used in development to 4.7.5

### DIFF
--- a/.fcrepo_wrapper.yml
+++ b/.fcrepo_wrapper.yml
@@ -1,4 +1,5 @@
 # Place any default configuration for fcrepo_wrapper here
+version: 4.7.5
 port: 8984
 enable_jms: false
 fcrepo_home_dir: tmp/fcrepo4-development-data

--- a/config/fcrepo_wrapper_test.yml
+++ b/config/fcrepo_wrapper_test.yml
@@ -1,4 +1,5 @@
 #config/fcrepo_wrapper_test.yml.sample
+version: 4.7.5
 port: 8986
 enable_jms: false
 fcrepo_home_dir: tmp/fcrepo4-test-data


### PR DESCRIPTION
The `fcrepo_wrapper` tool defaults to version 4.7.3 of fedora.  That
version has known bugs that probably don't impact development use, but
this change updates us to use the same version as we run in production
to be on the safe side.

Prior to this commit, you'd see version 4.7.3 loaded in development:
BEFORE
```
mark@Marks-MacBook-Pro tenejo % bundle exec fcrepo_wrapper
Starting Fedora 4.7.3 on port 8984 ... [main] INFO org.eclipse.jetty.util.log - Logging initialized @976ms
```

AFTER
```
mark@Marks-MacBook-Pro tenejo % bundle exec fcrepo_wrapper
Starting Fedora 4.7.5 on port 8984 ... [main] INFO org.eclipse.jetty.util.log - Logging initialized @1066ms
```