### PR TITLE
Fix NameError when trying to view menus from dashboard

### DIFF
--- a/app/views/tenejo/dashboard/sidebar/_jobs.html.erb
+++ b/app/views/tenejo/dashboard/sidebar/_jobs.html.erb
@@ -1,15 +1,15 @@
 <% if can? :read, :admin_dashboard %>
   <li class='h5' id='dashboard-sidebar-jobs'><%= t('tenejo.admin.sidebar.jobs') %>
     <%= menu.nav_link('/tenejo/preflight/new',
-                      onclick: "dontChangeAccordion(event);") do %>
+                      onclick: "dontChangeAccordion(event);", id: 'dashboard-sidebar-preflight') do %>
       <span class="fa fa-paper-plane" aria-hidden="true"></span><span class="sidebar-action-text"><%= t('tenejo.admin.sidebar.preflight') %></span>
     <% end %>
-    <%= menu.nav_link(jobs_path,
-                      onclick: "dontChangeAccordion(event);") do %>
+    <%= menu.nav_link('/jobs',
+                      onclick: "dontChangeAccordion(event);", id: 'dashboard-sidebar-job-status') do %>
       <span class="fa fa-cogs" aria-hidden="true"></span><span class="sidebar-action-text"><%= t('tenejo.admin.sidebar.jobs') %></span>
     <% end %>
     <%= menu.nav_link('/dashboard/sidekiq',
-                      onclick: "dontChangeAccordion(event);") do %>
+                      onclick: "dontChangeAccordion(event);", id: 'dashboard-sidebar-sidekiq') do %>
       <span class="fa fa-hourglass-half" aria-hidden="true"></span><span class="sidebar-action-text">Sidekiq</span>
     <% end %>
   </li>

--- a/spec/system/dashboard_spec.rb
+++ b/spec/system/dashboard_spec.rb
@@ -47,10 +47,16 @@ RSpec.describe 'dashboard' do
       expect(page).to have_link(href: sidekiq_dashboard_path)
     end
 
+    # We need an engine routing test because Hrax namespaced controllers
+    # don't access tenejo routes as expected
+    it 'allows Hyrax controllers to access tenejo paths' do
+      sign_in admin
+      expect { visit('dashboard/my/works') }.not_to raise_exception
+      expect(page).to have_link('dashboard-sidebar-job-status')
+    end
+
     it 'has a link to job statuses' do
-      # NOTE: jobs_path yields `/jobs` here,
-      # but includes the locale when rendered: `/jobs?locale=en`
-      expect(page).to have_link(href: "#{jobs_path}?locale=en")
+      expect(page).to have_link(href: '/jobs')
     end
   end
 end


### PR DESCRIPTION
When a user visited any of the Hyrax controllers from the dashboard
(e.g. works, collections, profile, etc.) the page gave a NameError:
`undefined local variable or method 'jobs_path'`

Controllers from the Hyrax engine don't appear to have access to
route helpers for controllers in the parent application (Tenejo),
so I replaced the helper with the literal path in the problem view.