### PR TITLE
Restrict access to create jobs and view job status to admin users

### DIFF
--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 class JobsController < ApplicationController
   before_action :set_job, only: %i[show edit update destroy]
+  before_action :authenticate_user!
+  before_action :ensure_admin!
   with_themed_layout 'dashboard'
 
   # GET /jobs or /jobs.json
@@ -61,6 +63,10 @@ class JobsController < ApplicationController
   end
 
   private
+
+  def ensure_admin!
+    authorize! :read, :admin_dashboard
+  end
 
   # Use callbacks to share common setup or constraints between actions.
   def set_job

--- a/spec/requests/jobs_spec.rb
+++ b/spec/requests/jobs_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "/jobs", type: :request do
   # adjust the attributes here as well.
   let(:valid_attributes) {
     { type: nil,
-      user: user,
+      user: admin,
       label: "Label",
       status: "Status",
       collections: 2,
@@ -30,10 +30,10 @@ RSpec.describe "/jobs", type: :request do
     skip("Add a hash of attributes invalid for your model")
   }
 
-  let(:user) { User.create(email: 'test@example.com', password: '123456') }
+  let(:admin) { User.create(email: 'test@example.com', password: '123456', roles: [Role.create(name: 'admin')]) }
 
   before do
-    sign_in user
+    sign_in admin
   end
 
   describe "GET /index" do

--- a/spec/system/job_spec.rb
+++ b/spec/system/job_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe 'jobs dashboard', type: :system do
+  before do
+    driven_by(:rack_test)
+  end
+
+  let(:user) { User.new(email: 'user@example.com') }
+  let(:admin) { User.new(email: 'admin@example.com', roles: [admin_role]) }
+  let(:admin_role) { Role.new(name: 'admin') }
+
+  context 'restricts non-admin users' do
+    it 'redirects guests to login' do
+      visit jobs_url
+      expect(page.current_path).to eq new_user_session_path
+    end
+
+    it 'gives non-admins an "unauthorized" error' do
+      sign_in user
+      visit jobs_url
+      expect(page).to have_text "You are not authorized to access this page."
+    end
+  end
+
+  context 'allows admin users' do
+    it 'view the jobs status page' do
+      sign_in admin
+      visit jobs_url
+      expect(page.current_path).to eq jobs_path
+      expect(page).to have_selector('tr th', text: 'Type')
+    end
+  end
+end


### PR DESCRIPTION
* Guest users need to login before viewing jobs
* Non-admins are restricted from viewing and creating jobs
* Admins can view and create jobs