### PR TITLE
Add a Preflight job type to allow uploading and persisting CSVs

### DIFF
--- a/app/controllers/preflights_controller.rb
+++ b/app/controllers/preflights_controller.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+class PreflightsController < JobsController
+  with_themed_layout 'dashboard'
+
+  def index
+    redirect_to jobs_url
+  end
+
+  def new
+    @job = Preflight.new
+  end
+
+  def create
+    @job = Preflight.new(job_params.merge({ user: current_user }))
+
+    respond_to do |format|
+      if @job.save
+        format.html { redirect_to @job, notice: "Job was successfully created." }
+        format.json { render :show, status: :created, location: @job }
+      else
+        format.html { render :new, status: :unprocessable_entity }
+        format.json { render json: @job.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # Only allow a list of trusted parameters through.
+  def job_params
+    params.require(:preflight).permit(:manifest)
+  end
+end

--- a/app/models/preflight.rb
+++ b/app/models/preflight.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+class Preflight < Job
+  has_one_attached :manifest
+  validate :manifest_attached
+
+  private
+
+  def manifest_attached
+    return if manifest.attached?
+    errors.add(:manifest, "must be attached")
+  end
+end

--- a/app/views/jobs/new.html.erb
+++ b/app/views/jobs/new.html.erb
@@ -1,5 +1,11 @@
 <h1>New Job</h1>
 
-<%= render 'form', job: @job %>
+<p>Please choose a job type:</p>
+
+<ul>
+  <% Job.subclasses.each do |job_type| %>
+    <li><%= link_to "New #{job_type.name}", "/#{job_type.name.downcase.pluralize}/new" %></li>
+  <% end %>
+</ul>
 
 <%= link_to 'Back', jobs_path %>

--- a/app/views/jobs/show.html.erb
+++ b/app/views/jobs/show.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <p>
   <strong>Type:</strong>
   <%= @job.type %>

--- a/app/views/preflights/new.html.erb
+++ b/app/views/preflights/new.html.erb
@@ -1,0 +1,25 @@
+<h1>New <%= @job.class %></h1>
+
+<%= form_with(model: @job, local: true) do |form| %>
+  <% if @job.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(@job.errors.count, "error") %> prohibited this job from being saved:</h2>
+
+      <ul>
+        <% @job.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.label :manifest %>
+    <%= form.file_field :manifest %>
+  </div>
+  <br/>
+  <%= form.hidden_field :placeholder, value: true %>
+  <div class="actions">
+    <%= form.submit 'Submit', type: 'submit' %>
+  </div>
+<% end %>

--- a/app/views/preflights/show.html.erb
+++ b/app/views/preflights/show.html.erb
@@ -1,0 +1,48 @@
+<h1>Preflight Job #<%= @job&.id %></h1>
+
+<div id="preflight-user"><p>
+  <strong>User:</strong>
+  <%= @job&.user %>
+</p></div>
+
+<div id="preflight-manifest"><p>
+  <strong>File:</strong>
+  <% if @job&.manifest&.filename %>
+    <%= link_to(@job.manifest.filename, rails_blob_path(@job.manifest, disposition: 'attachment')) %>
+  <% else %>
+    --
+  <% end %>
+</p></div>
+
+<div id="preflight-created_at"><p>
+  <strong>Submitted:</strong>
+  <%= @job&.created_at %>
+</p></div>
+
+
+<div id="preflight-status"><p>
+  <strong>Status:</strong>
+  <%= @job&.status || 'Unknown'%>
+</p></div>
+
+<div id="preflight-completed_at"><p>
+  <strong>Completed at:</strong>
+  <%= @job&.completed_at || '--' %>
+</p></div>
+
+<div id="preflight-collections"><p>
+  <strong>Collections:</strong>
+  <%= @job&.collections || '--' %>
+</p></div>
+
+<div id="preflight-works"><p>
+  <strong>Works:</strong>
+  <%= @job&.works || '--' %>
+</p></div>
+
+<div id="preflight-files"><p>
+  <strong>Files:</strong>
+  <%= @job&.files || '--' %>
+</p></div>
+
+<%= link_to 'Back', jobs_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@
 require 'sidekiq/web'
 Rails.application.routes.draw do
   resources :jobs
+  resources :preflights, only: [:index, :new, :create, :show]
   namespace :tenejo do
     get 'preflight/new'
     get 'preflight/show'

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -2,5 +2,22 @@
 require 'rails_helper'
 
 RSpec.describe Job, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:user) { FactoryBot.create(:user) }
+
+  it 'does not have a default user' do
+    job = described_class.new
+    expect(job.user).to be_nil
+  end
+
+  it 'cannot be saved without a valid user' do
+    job = described_class.new
+    expect { job.save! }.to raise_error(ActiveRecord::RecordInvalid, 'Validation failed: User must exist')
+  end
+
+  it 'saves with a valid user' do
+    job = described_class.new(user: user)
+    expect { job.save! }.not_to raise_error
+    job.reload
+    expect(job.user).to eq user
+  end
 end

--- a/spec/models/preflight_spec.rb
+++ b/spec/models/preflight_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Preflight, type: :model do
+  let(:user) { FactoryBot.create(:user) }
+
+  it 'inherits .type via STI' do
+    job = described_class.new
+    expect(job.type).to eq 'Preflight'
+  end
+
+  it 'requires a file' do
+    job = described_class.new(user: user)
+    expect { job.save! }.to raise_exception(ActiveRecord::RecordInvalid, /Manifest must be attached/)
+  end
+
+  it 'persists the associated file' do
+    job = described_class.new(user: user)
+    # attach file
+    empty_csv = Rails.root.join('spec', 'fixtures', 'csv', 'empty.csv')
+    job.manifest.attach(io: File.open(empty_csv), filename: 'empty.csv', content_type: 'text/csv')
+    job.save!
+    found_job = described_class.find(job.id)
+    expect(found_job.manifest).to be_a_kind_of ActiveStorage::Attached::One
+    expect(found_job.manifest.filename).to eq 'empty.csv'
+    # active storage files are not deleted automatically
+    found_job.manifest.purge
+  end
+end

--- a/spec/requests/preflight_request_spec.rb
+++ b/spec/requests/preflight_request_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe "/preflights", type: :request do
+  let(:tempfile) { fixture_file_upload('csv/empty.csv') }
+  let(:admin) { User.create(email: 'test@example.com', password: '123456', roles: [Role.create(name: 'admin')]) }
+  let(:preflight) { Preflight.new(user: admin, manifest: tempfile) }
+
+  before do
+    sign_in admin
+  end
+
+  describe "GET /index" do
+    it "redirects to /jobs/index" do
+      preflight.save!
+      get preflights_path
+      expect(response).to redirect_to jobs_path
+    end
+  end
+
+  describe "GET /new" do
+    it "renders a successful response" do
+      get new_preflight_path
+      expect(response).to render_template('preflights/new')
+    end
+  end
+
+  describe "POST /create" do
+    let(:valid_attributes) { { user: admin, manifest: tempfile } }
+    context "with valid parameters" do
+      it "creates a new Preflight job" do
+        expect {
+          post preflights_path, params: { preflight: valid_attributes }
+        }.to change(Job, :count).by(1)
+      end
+
+      it "redirects to the created job" do
+        post preflights_path, params: { preflight: valid_attributes }
+        expect(response).to redirect_to(preflight_url(Job.last))
+      end
+    end
+
+    context "with invalid parameters" do
+      let(:invalid_attributes) { { field: 'invalid' } }
+      it "does not create a new Job" do
+        expect {
+          post preflights_path, params: { preflight: invalid_attributes }
+        }.to change(Job, :count).by(0)
+      end
+
+      it "renders a successful response (i.e. to display the 'new' template)" do
+        post preflights_path, params: { preflight: invalid_attributes }
+        expect(response).to be_unprocessable
+        expect(response).to render_template('preflights/new')
+      end
+    end
+  end
+end

--- a/spec/routing/preflights_routing_spec.rb
+++ b/spec/routing/preflights_routing_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe PreflightsController, type: :routing do
+  describe "routing" do
+    it "routes to #index" do
+      expect(get: "/preflights").to route_to("preflights#index")
+    end
+
+    it "routes to #new" do
+      expect(get: "/preflights/new").to route_to("preflights#new")
+    end
+
+    it "routes to #show" do
+      expect(get: "/preflights/1").to route_to("preflights#show", id: "1")
+    end
+
+    it "routes to #create" do
+      expect(post: "/preflights").to route_to("preflights#create")
+    end
+
+    # Preflight jobs are not editable after creation
+    context 'invalid routes' do
+      it "does not route to #edit" do
+        expect(get: "/preflights/1/edit").not_to be_routable
+      end
+
+      it "does not route to #update via PUT" do
+        expect(put: "/preflights/1").not_to be_routable
+      end
+
+      it "does not route to #update via PATCH" do
+        expect(patch: "/preflights/1").not_to be_routable
+      end
+
+      it "does not route to #destroy" do
+        expect(delete: "/preflights/1").not_to be_routable
+      end
+    end
+  end
+end

--- a/spec/views/jobs/new.html.erb_spec.rb
+++ b/spec/views/jobs/new.html.erb_spec.rb
@@ -2,36 +2,11 @@
 require 'rails_helper'
 
 RSpec.describe "jobs/new", type: :view do
-  before do
-    assign(:job, Job.new(
-      type: nil,
-      label: "MyString",
-      user: nil,
-      status: "MyString",
-      collections: 1,
-      works: 1,
-      files: 1
-    ))
-  end
-
-  # Scaffold generated test - should be replaced when additional functionality is developed
-  it "renders new job form" do
+  it 'gives links to job subclasses' do
+    Job1Type = Class.new(Job)
+    Job2Type = Class.new(Job)
     render
-
-    assert_select "form[action=?][method=?]", jobs_path, "post" do
-      assert_select "input[name=?]", "job[type]"
-
-      assert_select "input[name=?]", "job[label]"
-
-      assert_select "input[name=?]", "job[user_id]"
-
-      assert_select "input[name=?]", "job[status]"
-
-      assert_select "input[name=?]", "job[collections]"
-
-      assert_select "input[name=?]", "job[works]"
-
-      assert_select "input[name=?]", "job[files]"
-    end
+    expect(rendered).to have_link('New Job1Type', href: '/job1types/new')
+    expect(rendered).to have_link('New Job2Type', href: '/job2types/new')
   end
 end

--- a/spec/views/jobs/show.html.erb_spec.rb
+++ b/spec/views/jobs/show.html.erb_spec.rb
@@ -4,26 +4,27 @@ require 'rails_helper'
 RSpec.describe "jobs/show", type: :view do
   let(:user) { User.create(email: 'test@example.com', password: '123456') }
   before do
-    @job = assign(:job, Job.create!(
-      type: nil,
-      label: "Label",
-      user: user,
-      status: "Status",
-      collections: 2,
-      works: 3,
-      files: 4
-    ))
+    @job = Job.create!(
+       type: nil,
+       label: "test job",
+       user: user,
+       status: :completed,
+       collections: 11,
+       works: 13,
+       files: 17
+     )
   end
 
   # Scaffold generated test - should be replaced when additional functionality is developed
   it "renders attributes in <p>" do
     render
-    expect(rendered).to match(/Type/)
-    expect(rendered).to match(/Label/)
-    expect(rendered).to match(//)
-    expect(rendered).to match(/Status/)
-    expect(rendered).to match(/2/)
-    expect(rendered).to match(/3/)
-    expect(rendered).to match(/4/)
+    expect(rendered).to match('Type')
+    expect(rendered).to match('Label')
+    expect(rendered).to match('test job')
+    expect(rendered).to match('Status')
+    expect(rendered).to match('completed')
+    expect(rendered).to match('11')
+    expect(rendered).to match('13')
+    expect(rendered).to match('17')
   end
 end

--- a/spec/views/preflights/new.html.erb_spec.rb
+++ b/spec/views/preflights/new.html.erb_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe "preflights/new", type: :view do
+  it 'shows the expected preflight form fields', :aggregate_failures do
+    @job = Preflight.new
+    render
+    expect(rendered).to have_selector('h1', text: 'New Preflight')
+    expect(rendered).to have_field('preflight[manifest]', type: 'file')
+    expect(rendered).to have_button('Submit', type: 'submit')
+    assert_select 'form[action=?][method=?]', preflights_path, 'post'
+  end
+
+  it 'renders form errors' do
+    job_with_errors = Preflight.new
+    job_with_errors.errors.messages[:fake] << 'error message'
+    @job = job_with_errors
+    render
+    expect(rendered).to have_selector('#error_explanation', text: 'Fake error message')
+  end
+end

--- a/spec/views/preflights/show.html.erb_spec.rb
+++ b/spec/views/preflights/show.html.erb_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe "preflights/show", type: :view do
+  let(:user) { FactoryBot.create(:user) }
+  let(:tempfile) { fixture_file_upload('csv/empty.csv') }
+  let(:completion_time) { Time.current.round }
+  let(:job) {
+    Preflight.new(
+      user: user,
+      manifest: tempfile,
+      status: :completed,
+      completed_at: completion_time,
+      works: 13,
+      files: 17
+    )
+  }
+
+  it "renders attributes", :aggregate_failures do
+    @job = job
+    render
+    expect(rendered).to have_selector('#preflight-user', text: user)
+    expect(rendered).to have_selector('#preflight-manifest', text: 'empty.csv')
+    expect(rendered).to have_selector('#preflight-status', text: 'completed')
+    expect(rendered).to have_selector('#preflight-created_at', text: job.created_at)
+    expect(rendered).to have_selector('#preflight-completed_at', text: completion_time)
+    expect(rendered).to have_selector('#preflight-collections', text: '--')
+    expect(rendered).to have_selector('#preflight-works', text: '13')
+    expect(rendered).to have_selector('#preflight-files', text: '17')
+    expect(rendered).to have_link(text: 'empty.csv')
+  end
+
+  it "handles missing attributes gracefully" do
+    @job = nil
+    expect { render }.not_to raise_error
+  end
+end


### PR DESCRIPTION
Adds a Job subclass called Preflight that allows the user to upload
a file, persist it to the server, and download the file from
Preflight job show page.

![image](https://user-images.githubusercontent.com/3064318/143780117-ddde65d6-6d8c-4874-abc5-73a3d7916154.png)

![image](https://user-images.githubusercontent.com/3064318/143780225-af6d1f30-065f-48db-92d5-1ccea6af9a9d.png)


![image](https://user-images.githubusercontent.com/3064318/143780190-d8b0cd43-7093-43cb-9406-56017fd5f4fb.png)
