### PR TITLE
Run preflight validations when a CSV is uploaded

### DIFF
--- a/app/controllers/preflights_controller.rb
+++ b/app/controllers/preflights_controller.rb
@@ -10,8 +10,13 @@ class PreflightsController < JobsController
     @job = Preflight.new
   end
 
+  def show
+    @preflight_graph = Tenejo::Preflight.process_csv(@job.manifest.download)
+  end
+
   def create
     @job = Preflight.new(job_params.merge({ user: current_user }))
+    run_preflight(@job) if @job.validate
 
     respond_to do |format|
       if @job.save
@@ -27,5 +32,17 @@ class PreflightsController < JobsController
   # Only allow a list of trusted parameters through.
   def job_params
     params.require(:preflight).permit(:manifest)
+  end
+
+  private
+
+  def run_preflight(job)
+    manifest = job_params[:manifest].tempfile.path
+    preflight_graph = Tenejo::Preflight.read_csv(manifest)
+    job.collections = preflight_graph[:collection].count
+    job.works = preflight_graph[:work].count
+    job.files = preflight_graph[:file].count
+    job.completed_at = Time.current
+    job.status = :completed
   end
 end

--- a/app/views/preflights/show.html.erb
+++ b/app/views/preflights/show.html.erb
@@ -1,5 +1,11 @@
 <h1>Preflight Job #<%= @job&.id %></h1>
 
+<%# TODO %>
+<%# This view is really large and could reasonably be broken into partials. %>
+<%# I'm leaving it in a single file for now because the  %>
+<%# API for the preflight graph is still in flux %>
+
+<%# JOB OVERVIEW %>
 <div id="preflight-user"><p>
   <strong>User:</strong>
   <%= @job&.user %>
@@ -18,7 +24,6 @@
   <strong>Submitted:</strong>
   <%= @job&.created_at %>
 </p></div>
-
 
 <div id="preflight-status"><p>
   <strong>Status:</strong>
@@ -46,3 +51,134 @@
 </p></div>
 
 <%= link_to 'Back', jobs_path %>
+
+<h2>Analysis</h2>
+
+<%# ERRORS %>
+<% unless @preflight_graph[:fatal_errors].blank? %>
+  <div class="preflight-errors well well-sm">
+    <h4 class="bg-danger"">Errors</h4>
+    <ul>
+      <% @preflight_graph[:fatal_errors].each do |error| %>
+        <li><%= error %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
+
+<%# WARNINGS %>
+<% unless @preflight_graph[:warnings].blank? %>
+  <div class="preflight-warnings well well-sm">
+    <h4 class="bg-warning">Warnings</h4>
+    <ul>
+      <% @preflight_graph[:warnings].each do |warning| %>
+        <li><%= warning %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
+
+<%# COLLECTIONS %>
+<% unless @preflight_graph[:collection].blank? %>
+  <div class="preflight-collections well well-sm">
+    <h4 class="bg-info">Collections</h4>
+    <table>
+      <colgroup>
+        <col style="width: 5rem;">
+        <col style="width: 10rem;">
+        <col style="width: 15rem;">
+        <col>
+      </colgroup>
+      <thead><tr>
+        <th>Row</th>
+        <th>Visibility</th>
+        <th>Identifier</th>
+        <th>Title</th>
+      </tr></thead>
+      <tbody>
+      <% @preflight_graph[:collection].each do |item| %>
+        <tr>
+          <td><%= item.lineno %></td>
+          <td><%= item.visibility %></td>
+          <td><%= item.identifier %></td>
+          <td><%= item.title %></td>
+        </tr>
+      <% end %>
+      </tbody>
+    </table>
+  </div>
+<% end %>
+
+<%# WORKS %>
+<% unless @preflight_graph[:work].blank? %>
+  <div class="preflight-works well well-sm">
+    <h4 class="bg-info">Works</h4>
+    <table>
+      <colgroup>
+        <col style="width: 5rem;">
+        <col style="width: 10rem;">
+        <col style="width: 15rem;">
+        <col>
+      </colgroup>
+      <thead><tr>
+        <th>Row</th>
+        <th>Visibility</th>
+        <th>Identifier</th>
+        <th>Title</th>
+      </tr></thead>
+      <tbody>
+      <% @preflight_graph[:work].each do |item| %>
+        <tr>
+          <td><%= item.lineno %></td>
+          <td><%= item.visibility %></td>
+          <td><%= item.identifier %></td>
+          <td><%= item.title %></td>
+        </tr>
+      <% end %>
+      </tbody>
+    </table>
+  </div>
+<% end %>
+
+<%# FILES %>
+<% unless @preflight_graph[:file].blank? %>
+  <div class="preflight-files well well-sm">
+    <h4 class="bg-info">Files</h4>
+    <table>
+      <colgroup>
+        <col style="width: 5rem;">
+        <col style="width: 10rem;">
+        <col style="width: 15rem;">
+        <col>
+      </colgroup>
+      <thead><tr>
+        <th>Row</th>
+        <th>Visibility</th>
+        <th>Identifier</th>
+        <th>Title</th>
+      </tr></thead>
+      <tbody>
+      <% @preflight_graph[:file].each do |item| %>
+        <tr>
+          <td><%= item.lineno %></td>
+          <td><%= item.parent %></td>
+          <td><%= item.import_path %></td>
+          <td><%= item.file %></td>
+        </tr>
+      <% end %>
+      </tbody>
+    </table>
+  </div>
+<% end %>
+
+<%# RAW GRAPH %>
+<p>
+  <button class="btn btn-primary" type="button" data-toggle="collapse" data-target="#rawPreflight" aria-expanded="false" aria-controls="rawPreflight">
+    Show raw preflight
+  </button>
+</p>
+<div class="collapse" id="rawPreflight">
+  <div class="card card-body">
+    <p><%= @preflight_graph %></p>
+  </div>
+</div>

--- a/spec/views/preflights/show.html.erb_spec.rb
+++ b/spec/views/preflights/show.html.erb_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe "preflights/show", type: :view do
 
   it "renders attributes", :aggregate_failures do
     @job = job
+    @preflight_graph = {}
     render
     expect(rendered).to have_selector('#preflight-user', text: user)
     expect(rendered).to have_selector('#preflight-manifest', text: 'empty.csv')
@@ -32,6 +33,59 @@ RSpec.describe "preflights/show", type: :view do
 
   it "handles missing attributes gracefully" do
     @job = nil
+    @preflight_graph = {}
     expect { render }.not_to raise_error
+  end
+
+  it "shows any errors" do
+    @preflight_graph = { fatal_errors: ["No data was detected"] }
+    render
+    expect(rendered).to have_selector('.preflight-errors', text: 'No data was detected')
+  end
+
+  it "shows any warnings", :aggregate_failures do
+    @preflight_graph = { warnings: ["Could not find parent work \"GONE?\" for file \"neverwhere.jpg\" on line 6", "Could not find parent work \"NONA\" for work \"MPC009\" on line 11"] }
+    render
+    expect(rendered).to have_selector('.preflight-warnings', text: 'Warnings')
+    expect(rendered).to have_selector('li', text: 'Could not find parent work', count: 2)
+  end
+
+  it "shows any collections", :aggregate_failures do
+    CollectionDummy = Struct.new(:lineno, :visibility, :identifier, :title, keyword_init: true)
+    @preflight_graph = {
+      collection: [
+        CollectionDummy.new(title: 'Collection 1', lineno: 2),
+        CollectionDummy.new(title: 'Collection 2', lineno: 3)
+      ]
+    }
+    render
+    expect(rendered).to have_selector('.preflight-collections', text: 'Collections')
+    expect(rendered).to have_selector('tr td', text: 'Collection 2')
+  end
+
+  it "shows any works", :aggregate_failures do
+    PFPlaceholder = Struct.new(:lineno, :visibility, :identifier, :title, keyword_init: true)
+    @preflight_graph = {
+      work: [
+        PFPlaceholder.new(title: 'Work 1', lineno: 5),
+        PFPlaceholder.new(title: 'Work 2', lineno: 7)
+      ]
+    }
+    render
+    expect(rendered).to have_selector('.preflight-works', text: 'Works')
+    expect(rendered).to have_selector('tr td', text: 'Work 2')
+  end
+
+  it "shows any files", :aggregate_failures do
+    FileDummy = Struct.new(:lineno, :parent, :import_path, :file, keyword_init: true)
+    @preflight_graph = {
+      file: [
+        FileDummy.new(file: 'hydra.tiff', lineno: 8),
+        FileDummy.new(file: 'hydra.tiff', lineno: 4)
+      ]
+    }
+    render
+    expect(rendered).to have_selector('.preflight-files', text: 'Files')
+    expect(rendered).to have_selector('tr td', text: 'hydra.tiff', count: 2)
   end
 end


### PR DESCRIPTION
* Runs preflight when a CSV is uploaded
* Extracts collection, work, and file counts and saves them to the job
* Displays preflight validation information on the job's show page

NOTE: the preflight graph is re-generated every time the show page
is loaded.  Going forward we should explore ways to persist the graph
data to the job.

![image](https://user-images.githubusercontent.com/3064318/143811162-8802bb6d-dc5c-499c-9b4a-084864f46b6a.png)
