### PR TITLE
Add initial branding pages

### DIFF
--- a/app/assets/stylesheets/themes.scss
+++ b/app/assets/stylesheets/themes.scss
@@ -1,0 +1,29 @@
+// Place all the styles related to the Themes controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/
+
+#homepage-preview {
+  width: 40vw;
+  font-size: 1vw;
+  margin-left: auto;
+  margin-right: auto;
+  margin-top: 3em;
+  alignment: center;
+  border: #2E2F30;
+}
+
+.preview-header {
+  width: 100%;
+  height: 7em;
+}
+
+.preview-body {
+  height: 8em;
+  padding: 1em;
+}
+
+.preview-footer {
+  width: 100%;
+  height: 2em;
+  text-align: center
+}

--- a/app/controllers/themes_controller.rb
+++ b/app/controllers/themes_controller.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+class ThemesController < ApplicationController
+  before_action :set_theme, only: %i[show edit update destroy]
+  before_action :authenticate_user!
+  before_action :ensure_admin!
+  with_themed_layout 'dashboard'
+
+  # GET /themes or /themes.json
+  # def index
+  #   @themes = Theme.all
+  # end
+  #
+  # # GET /themes/1 or /themes/1.json
+  # def show
+  # end
+  #
+  # # GET /themes/new
+  # def new
+  #   @theme = Theme.new
+  # end
+
+  # GET /themes/1/edit
+  def edit
+  end
+
+  # POST /themes or /themes.json
+  # def create
+  #   @theme = Theme.new(theme_params)
+  #
+  #   respond_to do |format|
+  #     if @theme.save
+  #       format.html { redirect_to @theme, notice: "Theme was successfully created." }
+  #       format.json { render :show, status: :created, location: @theme }
+  #     else
+  #       format.html { render :new, status: :unprocessable_entity }
+  #       format.json { render json: @theme.errors, status: :unprocessable_entity }
+  #     end
+  #   end
+  # end
+
+  # PATCH/PUT /themes/1 or /themes/1.json
+  def update
+    params[:theme] = Theme::DEFAULTS if params[:reset]
+    if @theme.update(theme_params)
+      redirect_to edit_theme_path, notice: "Theme was successfully updated."
+    else
+      render edit_theme_path, status: :unprocessable_entity
+    end
+  end
+
+  # DELETE /themes/1 or /themes/1.json
+  # def destroy
+  #   @theme.destroy
+  #   respond_to do |format|
+  #     format.html { redirect_to themes_url, notice: "Theme was successfully destroyed." }
+  #     format.json { head :no_content }
+  #   end
+  # end
+
+  private
+
+  # Use callbacks to share common setup or constraints between actions.
+  def set_theme
+    # @theme = Theme.find(params[:id])
+    @theme = Theme.current_theme
+  end
+
+  # Only allow a list of trusted parameters through.
+  def theme_params
+    params.require(:theme).permit(Theme::DEFAULTS.keys)
+  end
+
+  # Restrict theme access to admins
+  def ensure_admin!
+    authorize! :read, :admin_dashboard
+  end
+end

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+class Theme < ApplicationRecord
+  DEFAULTS = ActiveSupport::HashWithIndifferentAccess.new(
+    site_title: 'Tenejo',
+    primary_color: '#000000',
+    accent_color: '#D35F00',
+    primary_text_color: '#1A1A1A',
+    accent_text_color: '#FFFFFF',
+    background_color: '#FFFFFF'
+  )
+
+  after_initialize :merge_defaults
+
+  def merge_defaults
+    self.attributes = attributes.compact.reverse_merge(DEFAULTS)
+  end
+
+  def self.current_theme
+    @current_theme ||=
+      begin
+        Theme.find(1)
+      rescue
+        Theme.create(id: 1)
+      end
+  end
+
+  def reset_to_defaults
+    self.attributes = attributes.merge(DEFAULTS)
+  end
+end

--- a/app/views/shared/_appearance_styles.html.erb
+++ b/app/views/shared/_appearance_styles.html.erb
@@ -1,0 +1,62 @@
+<%# Include the original Hyrax version of this partial to pull in Hyrax dynamic styles %>
+<%= render(file: File.join(Hyrax::Engine.root, 'app','views','shared','_appearance_styles')) %>
+
+<%# Styling for tenejo themed pages %>
+<%# TODO: break out static settings into app/assets/stylesheets/themes.scss %>
+
+<%# Font expierment %>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Truculenta&display=swap" rel="stylesheet">
+
+<% theme = Theme.current_theme %>
+<style>
+    #homepage-preview {
+        font-family: 'Truculenta', sans-serif;
+        color: <%= theme.primary_text_color %>
+    }
+
+    .preview-header {
+        background-color: <%= theme.primary_color %>;
+        color: <%= theme.accent_text_color %>;
+    }
+
+    .preview-body {
+        background-color: <%= theme.background_color %>;
+    }
+
+    .preview-footer {
+        background-color: <%= theme.primary_color %>;
+        color: <%= theme.accent_text_color %>;
+    }
+
+    .preview-navbar-header {
+        width: 100%;
+        height: 2em;
+        background-color: <%= theme.accent_color %>
+    }
+
+    .preview-site-title {
+        margin-top: -1em;
+        text-align: center;
+        font-size: 130%;
+        margin-bottom: 1.25em
+
+    }
+    .preview-navbar-header ul {
+        list-style-type: none;
+        margin: 0;
+        padding: 0;
+        overflow: hidden;
+        float: left;
+    }
+
+    .preview-navbar-header ul li {
+        float: left;
+        padding: .5em;
+    }
+
+    .preview-navbar-search {
+        float: right;
+    }
+</style>

--- a/app/views/tenejo/dashboard/_sidebar.html.erb
+++ b/app/views/tenejo/dashboard/_sidebar.html.erb
@@ -7,7 +7,7 @@
     <%= render 'hyrax/dashboard/sidebar/repository_content', menu: menu %>
     <%= render 'tenejo/dashboard/sidebar/jobs', menu: menu %>
     <%= render 'hyrax/dashboard/sidebar/tasks', menu: menu %>
-    <%= render 'hyrax/dashboard/sidebar/configuration', menu: menu %>
+    <%= render 'tenejo/dashboard/sidebar/configuration', menu: menu %>
     <%= render 'hyrax/dashboard/sidebar/activity', menu: menu %>
   </ul>
 </nav>

--- a/app/views/tenejo/dashboard/sidebar/_configuration.html.erb
+++ b/app/views/tenejo/dashboard/sidebar/_configuration.html.erb
@@ -1,0 +1,43 @@
+  <% if menu.show_configuration? %>
+    <li class="h5"><%= t('hyrax.admin.sidebar.configuration') %></li>
+    <% if can?(:update, :appearance) %>
+      <%= menu.nav_link('/theme/edit', onclick: "dontChangeAccordion(event);", id: 'dashboard-sidebar-theme') do %>
+        <span class="fa fa-university" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('tenejo.admin.sidebar.theme') %></span>
+      <% end %>
+    <% end %>
+
+    <li>
+      <%= menu.collapsable_section t('hyrax.admin.sidebar.settings'),
+                                   icon_class: "fa fa-cog",
+                                   id: 'collapseSettings',
+                                   open: menu.settings_section? do %>
+        <% if can?(:update, :appearance) %>
+          <%= menu.nav_link(hyrax.admin_appearance_path) do %>
+            <span class="fa fa-paint-brush" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.appearance') %></span>
+          <% end %>
+        <% end %>
+        <% if can?(:manage, :collection_types) %>
+          <%= menu.nav_link(hyrax.admin_collection_types_path) do %>
+            <span class="fa fa-folder-open" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.collection_types') %></span>
+          <% end %>
+        <% end %>
+        <% if can?(:manage, Hyrax::Feature) %>
+          <%= menu.nav_link(hyrax.edit_pages_path) do %>
+            <span class="fa fa-file-text-o" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.pages') %></span>
+          <% end %>
+          <%= menu.nav_link(hyrax.edit_content_blocks_path) do %>
+            <span class="fa fa-square-o" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.content_blocks') %></span>
+          <% end %>
+          <%= menu.nav_link(hyrax.admin_features_path) do %>
+            <span class="fa fa-wrench" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.technical') %></span>
+          <% end %>
+        <% end %>
+      <% end %>
+    </li>
+
+    <% if can?(:manage, Sipity::WorkflowResponsibility) %>
+      <%= menu.nav_link(hyrax.admin_workflow_roles_path) do %>
+        <span class="fa fa-users" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.workflow_roles') %></span>
+      <% end %>
+    <% end %>
+  <% end %>

--- a/app/views/themes/_form.html.erb
+++ b/app/views/themes/_form.html.erb
@@ -1,0 +1,48 @@
+<%= form_with(model: theme, local: true) do |form| %>
+  <% if theme.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(theme.errors.count, "error") %> prohibited this theme from being saved:</h2>
+
+      <ul>
+      <% theme.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.label :site_title %>
+    <%= form.text_field :site_title %>
+  </div>
+
+  <div class="field">
+    <%= form.label :primary_color %>
+    <%= form.color_field :primary_color %>
+  </div>
+
+  <div class="field">
+    <%= form.label :accent_color %>
+    <%= form.color_field :accent_color %>
+  </div>
+
+  <div class="field">
+    <%= form.label :primary_text_color %>
+    <%= form.text_field :primary_text_color %>
+  </div>
+
+  <div class="field">
+    <%= form.label :accent_text_color %>
+    <%= form.text_field :accent_text_color %>
+  </div>
+
+  <div class="field">
+    <%= form.label :background_color %>
+    <%= form.text_field :background_color %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit 'Save Changes', name: 'save', class: 'btn btn-primary' %>
+    <%= form.submit 'Reset to Defaults', name: 'reset', class: 'btn btn-default' %>
+  </div>
+<% end %>

--- a/app/views/themes/_preview_home.html.erb
+++ b/app/views/themes/_preview_home.html.erb
@@ -1,0 +1,34 @@
+<div id='homepage-preview'>
+  <div class="homepage-body">
+    <div class="preview-header">
+      <div class="preview-masthead">
+        .masthead
+      </div>
+      <div class="preview-masthead-image">
+        .masthead-image
+        <div class="preview-site-title"><%= @theme.site_title %></div>
+        <div class="preview-navbar-header">
+          <ul class="">
+            <li>Home</li>
+            <li>About</li>
+            <li>Help</li>
+            <li>Contact</li>
+          </ul>
+          <div class="preview-navbar-search">
+            <form>
+              <label for="search-field-header">Search</label>
+              <input type="text" placeholder="Enter search terms" />
+              <button type="button" id="search-submit">Go</button>
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="preview-body">
+      Some homepage stuff goes here...
+    </div>
+    <div class="preview-footer">
+      Some footer stuff goes here...
+    </div>
+  </div>
+</div>

--- a/app/views/themes/edit.html.erb
+++ b/app/views/themes/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>Editing Theme</h1>
+
+<%= render 'form', theme: @theme %>
+
+<%= render 'preview_home', theme: @theme %>
+

--- a/config/locales/tenejo.en.yml
+++ b/config/locales/tenejo.en.yml
@@ -5,3 +5,4 @@ en:
       sidebar:
         jobs: Jobs
         preflight: Preflight
+        theme: Theme

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require 'sidekiq/web'
 Rails.application.routes.draw do
+  resource :theme, only: [:edit, :update]
   resources :jobs
   resources :preflights, only: [:index, :new, :create, :show]
 

--- a/db/migrate/20211129173942_create_themes.rb
+++ b/db/migrate/20211129173942_create_themes.rb
@@ -1,0 +1,14 @@
+class CreateThemes < ActiveRecord::Migration[5.2]
+  def change
+    create_table :themes do |t|
+      t.string :site_title
+      t.string :primary_color
+      t.string :accent_color
+      t.string :primary_text_color
+      t.string :accent_text_color
+      t.string :background_color
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_23_044640) do
+ActiveRecord::Schema.define(version: 2021_11_29_173942) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -510,6 +510,17 @@ ActiveRecord::Schema.define(version: 2021_11_23_044640) do
     t.boolean "active"
     t.boolean "allows_access_grant"
     t.index ["permission_template_id", "name"], name: "index_sipity_workflows_on_permission_template_and_name", unique: true
+  end
+
+  create_table "themes", force: :cascade do |t|
+    t.string "site_title"
+    t.string "primary_color"
+    t.string "accent_color"
+    t.string "primary_text_color"
+    t.string "accent_text_color"
+    t.string "background_color"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "tinymce_assets", force: :cascade do |t|

--- a/spec/models/theme_spec.rb
+++ b/spec/models/theme_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Theme, type: :model do
+  it 'initializes with default values', :aggregate_failures do
+    theme = described_class.new
+    expect(theme.site_title).to eq Theme::DEFAULTS[:site_title]
+    expect(theme.primary_color).to eq Theme::DEFAULTS[:primary_color]
+    expect(theme.accent_color).to eq Theme::DEFAULTS[:accent_color]
+    expect(theme.primary_text_color).to eq Theme::DEFAULTS[:primary_text_color]
+    expect(theme.accent_text_color).to eq Theme::DEFAULTS[:accent_text_color]
+    expect(theme.background_color).to eq Theme::DEFAULTS[:background_color]
+  end
+
+  it 'does not overwrite explicit intiialization values', :aggregate_failures do
+    theme = described_class.new(primary_color: '#ABCDEF')
+    expect(theme.site_title).to eq Theme::DEFAULTS[:site_title]
+    expect(theme.primary_color).to eq '#ABCDEF'
+  end
+
+  it 'has a #current_theme class method' do
+    expect(described_class.current_theme.id).to eq 1
+  end
+
+  it 'can .reset_to_defaults', :aggregate_failures do
+    theme = described_class.new(site_title: 'Not Your Average Default', primary_color: '#ABCDEF')
+    expect(theme.site_title).to eq 'Not Your Average Default'
+    expect(theme.primary_color).to eq '#ABCDEF'
+
+    theme.reset_to_defaults
+
+    expect(theme.site_title).to eq Theme::DEFAULTS[:site_title]
+    expect(theme.primary_color).to eq Theme::DEFAULTS[:primary_color]
+  end
+end

--- a/spec/requests/themes_spec.rb
+++ b/spec/requests/themes_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe "/themes", type: :request do
+  let(:valid_attributes) { Theme::DEFAULTS }
+  let(:invalid_attributes) { { elephant: true } }
+
+  before :all do
+    # Make sure current_theme is initialized outside of database transactions
+    Theme.current_theme
+  end
+
+  let(:admin) { FactoryBot.create(:user, :admin) }
+  before do
+    sign_in admin
+  end
+
+  describe "GET /edit" do
+    it "render a successful response" do
+      get edit_theme_path
+      expect(response).to be_successful
+    end
+
+    it 'renders in the dashboard layout' do
+      get edit_theme_path
+      expect(response).to render_template('layouts/hyrax/dashboard')
+    end
+  end
+
+  describe "PATCH /update" do
+    context "with valid parameters" do
+      let(:new_attributes) { { site_title: 'Updated', background_color: '#F5F5F5' } }
+
+      it "updates the requested theme" do
+        theme = Theme.current_theme
+        # ensure we're not in a flaky state from other tests
+        theme.reset_to_defaults
+        theme.save
+        patch theme_url(theme), params: { theme: new_attributes, format: 'html' }
+        theme.reload
+        expect(theme.site_title).to eq 'Updated'
+        expect(theme.background_color).to eq '#F5F5F5'
+      end
+
+      it "redirects to the theme" do
+        theme = Theme.current_theme
+        patch theme_url(theme), params: { theme: new_attributes }
+        theme.reload
+        expect(response).to redirect_to(edit_theme_path)
+      end
+    end
+
+    context "with invalid parameters" do
+      it "are ignored" do
+        theme = Theme.current_theme
+        patch theme_url(theme), params: { theme: invalid_attributes }
+        expect(response).to redirect_to(edit_theme_path)
+      end
+    end
+  end
+end

--- a/spec/routing/themes_routing_spec.rb
+++ b/spec/routing/themes_routing_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe ThemesController, type: :routing do
+  describe "routing" do
+    it "routes to #edit" do
+      expect(get: "/theme/edit").to route_to("themes#edit")
+    end
+
+    it "routes to #update via PUT" do
+      expect(put: "/theme").to route_to("themes#update")
+    end
+
+    it "routes to #update via PATCH" do
+      expect(patch: "/theme").to route_to("themes#update")
+    end
+  end
+
+  describe "un-routable" do
+    it "#edit individual themes" do
+      expect(get: "/themes/edit/1").not_to be_routable
+    end
+
+    it "#update individual themes via PUT" do
+      expect(put: "/themes/1").not_to be_routable
+    end
+
+    it "#update individual themes via PATCH" do
+      expect(patch: "/themes/1").not_to be_routable
+    end
+
+    it "routes to #index" do
+      expect(get: "/theme").not_to be_routable
+    end
+
+    it "routes to #new" do
+      expect(get: "/themes/new").not_to be_routable
+    end
+
+    it "routes to #show" do
+      expect(get: "/themes/1").not_to be_routable
+    end
+
+    it "routes to #create" do
+      expect(post: "/themes").not_to be_routable
+    end
+
+    it "routes to #destroy" do
+      expect(delete: "/themes/1").not_to be_routable
+    end
+  end
+end

--- a/spec/system/dashboard_spec.rb
+++ b/spec/system/dashboard_spec.rb
@@ -58,5 +58,9 @@ RSpec.describe 'dashboard' do
     it 'has a link to job statuses' do
       expect(page).to have_link(href: '/jobs')
     end
+
+    it 'has a link to the branding dashboard' do
+      expect(page).to have_link('dashboard-sidebar-theme', href: edit_theme_path)
+    end
   end
 end

--- a/spec/views/themes/edit.html.erb_spec.rb
+++ b/spec/views/themes/edit.html.erb_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe "themes/edit", type: :view do
+  before do
+    @theme = assign(:theme, Theme.create!(
+      site_title: "MyString",
+      primary_color: "MyString",
+      accent_color: "MyString",
+      primary_text_color: "MyString",
+      accent_text_color: "MyString",
+      background_color: "MyString"
+    ))
+  end
+
+  it "renders the edit theme form" do
+    render
+
+    assert_select "form[action=?][method=?]", theme_path, "post" do
+      assert_select "input[name=?]", "theme[site_title]"
+
+      assert_select "input[name=?]", "theme[primary_color]"
+
+      assert_select "input[name=?]", "theme[accent_color]"
+
+      assert_select "input[name=?]", "theme[primary_text_color]"
+
+      assert_select "input[name=?]", "theme[accent_text_color]"
+
+      assert_select "input[name=?]", "theme[background_color]"
+    end
+  end
+end


### PR DESCRIPTION
This commit provides the outline of a branding preview function by
providing an input form for key theming elements and a preview showing
how those settings would appear on a mock homepage.

The process works by injecting a dynamically generated css into the
header of all pages.  For the time being, I've scoped the css to only
affect the preview on the them page.

When we're ready to apply the styles site-wide, we can either change
the class names to match existing Hyrax classes, or create a cleaned-up
tenejo-specific version of the impacted layouts and views.

Style values are read from a `Theme` object.  The present code implements
a `#current_theme` class method that reads the values stored in the
`Theme` record with id `1`.  Saving that record persists the style settings
so they can be reloaded whenever the application is restarted.

![image](https://user-images.githubusercontent.com/3064318/143998162-a0a1190f-88e4-40a4-9b12-005710281c16.png)
