### PR TITLE
Clean up Theme initialization

### DIFF
--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -11,20 +11,19 @@ class Theme < ApplicationRecord
 
   after_initialize :merge_defaults
 
-  def merge_defaults
-    self.attributes = attributes.compact.reverse_merge(DEFAULTS)
-  end
-
   def self.current_theme
-    @current_theme ||=
-      begin
-        Theme.find(1)
-      rescue
-        Theme.create(id: 1)
-      end
+    @current_theme ||= Theme.find_or_create_by(id: 1) do |theme|
+      merge_defaults
+    end
   end
 
   def reset_to_defaults
     self.attributes = attributes.merge(DEFAULTS)
+  end
+
+  private
+
+  def merge_defaults
+    self.attributes = attributes.compact.reverse_merge(DEFAULTS)
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -85,3 +85,7 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 end
+
+before :suite do
+  Theme.current_theme
+end


### PR DESCRIPTION
Simplify the Theme setup and ensure tests don't delete the default
theme in a database transaction rollback.