### PR TITLE
Adds csv import job

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,9 +9,6 @@ AllCops:
     - db/**/*
     - bin/**/*
 
-RSpec/InstanceVariable:
-  Enabled: false
-
 Layout/HashAlignment:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,9 @@ AllCops:
     - db/**/*
     - bin/**/*
 
+RSpec/InstanceVariable:
+  Enabled: false
+
 Layout/HashAlignment:
   Enabled: false
 

--- a/app/jobs/ingest_job.rb
+++ b/app/jobs/ingest_job.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+require 'tenejo/preflight'
+require 'tenejo/csv_importer'
+class IngestJob < ApplicationJob
+  queue_as :default
+
+  def perform(filename)
+    # probably not optimal, but enough until we get
+    # import hammered out
+    Tenejo::CsvImporter.import(Tenejo::Preflight.process_csv(File.open(filename)))
+  end
+end

--- a/app/lib/tenejo/csv_importer.rb
+++ b/app/lib/tenejo/csv_importer.rb
@@ -43,14 +43,14 @@ module Tenejo
 
       graph[:collection].each do |collection_params|
         begin
-          collection = Collection.find(collection_params[:identifier])
+          collection = Collection.find(collection_params.identifier)
         rescue ActiveFedora::ObjectNotFoundError
-          collection = Collection.new(id: collection_params[:identifier], collection_type_gid: default_collection_type.gid)
+          collection = Collection.new(id: collection_params.identifier, collection_type_gid: default_collection_type.gid)
         end
-        collection.title = collection_params[:title]
-        collection.description = collection_params[:description]
+        collection.title = [collection_params.title]
+        collection.description = collection_params.description # is description really a column?
         collection.date_modified = collection.date_uploaded = Time.current
-        collection.save
+        collection.save!
       end
     end
   end

--- a/spec/jobs/ingest_job_spec.rb
+++ b/spec/jobs/ingest_job_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe IngestJob, type: :job do
+  describe "#perform_later" do
+    it "queues" do
+      ActiveJob::Base.queue_adapter = :test
+      expect {
+        described_class.perform_later("filename")
+      } .to have_enqueued_job.with("filename").on_queue(:default)
+    end
+    it "calls the importer with a graph made from a file" do
+      ActiveJob::Base.queue_adapter = :test
+      allow(Tenejo::CsvImporter).to receive(:import)
+      allow(Tenejo::Preflight).to receive(:process_csv).and_return "some graph"
+      described_class.perform_now(Rails.root.join("spec/fixtures/csv/fancy.csv"))
+      expect(Tenejo::CsvImporter).to have_received(:import).with("some graph")
+      expect(Tenejo::Preflight).to have_received(:process_csv)
+    end
+  end
+end

--- a/spec/lib/tenejo/csv_importer_spec.rb
+++ b/spec/lib/tenejo/csv_importer_spec.rb
@@ -30,6 +30,6 @@ RSpec.describe Tenejo::CsvImporter do
   end
 
   it 'saves titles' do
-    expect(Collection.where(title: 'Collection No. 2').count).to be >= 1
+    expect(Collection.where(title: 'The testing collection').count).to be >= 1
   end
 end

--- a/spec/lib/tenejo/csv_importer_spec.rb
+++ b/spec/lib/tenejo/csv_importer_spec.rb
@@ -3,34 +3,33 @@
 require 'rails_helper'
 
 RSpec.describe Tenejo::CsvImporter do
-  collection1 = { identifier: 'C01', title: ['Collection No. 1'], description: ['Bits & bobs'] }
-  collection2 = { identifier: 'C02', title: ['Collection No. 2'], description: ['Paper ephemera'] }
-  job_graph = { collection: [collection1, collection2] }
-
-  described_class.import(job_graph)
-  persisted = Collection.find('C01')
-
+  before :context do
+    graph = Tenejo::Preflight.read_csv(File.open("./spec/fixtures/csv/fancy.csv"))
+    @fixture = graph[:collection].find { |x| x.identifier == "TESTINGCOLLECTION" }
+    @fixture.identifier = Time.now.to_i.to_s # make sort of unique identifier
+    described_class.import(graph)
+    @persisted = Collection.find(@fixture.identifier)
+  end
+  after :context do
+    @persisted.delete
+  end
   it 'creates a persistent collection' do
-    expect(persisted).not_to be_nil
+    expect(@persisted).not_to be_nil
   end
 
   it 'creates collections with expected identifiers' do
-    expect(persisted.id).to eq 'C01'
+    expect(@persisted.id).to eq @fixture.identifier
   end
 
   it 'sets #date_uploaded' do
-    expect(persisted.date_uploaded.in_time_zone).to be_within(1.minute).of(Time.current)
+    expect(@persisted.date_uploaded.in_time_zone).to be_within(1.minute).of(Time.current)
   end
 
   it 'sets #date_modified to #date_uploaded' do
-    expect(persisted.date_modified).to eq persisted.date_uploaded
+    expect(@persisted.date_modified).to eq @persisted.date_uploaded
   end
 
   it 'saves titles' do
     expect(Collection.where(title: 'Collection No. 2').count).to be >= 1
-  end
-
-  it 'saves optional fields', :aggregate_failures do
-    expect(persisted.description).to include 'Bits & bobs'
   end
 end

--- a/spec/lib/tenejo/csv_importer_spec.rb
+++ b/spec/lib/tenejo/csv_importer_spec.rb
@@ -2,6 +2,7 @@
 # require './app/lib/tenejo/csv_importer'
 require 'rails_helper'
 
+# rubocop:disable RSpec/InstanceVariable
 RSpec.describe Tenejo::CsvImporter do
   before :context do
     graph = Tenejo::Preflight.read_csv(File.open("./spec/fixtures/csv/fancy.csv"))

--- a/spec/lib/tenejo/preflight_spec.rb
+++ b/spec/lib/tenejo/preflight_spec.rb
@@ -2,6 +2,7 @@
 require 'rails_helper'
 require 'fileutils'
 
+# rubocop:disable RSpec/InstanceVariable
 RSpec.describe Tenejo::Preflight do
   before :all do
     FileUtils.mkdir_p("tmp/uploads")


### PR DESCRIPTION
* Job re-calls pre-flight to regenerate the graph before passing in to
csv_importer, this should be improved as things form up a bit more
* Removes arbitrary (and incorrect) rubocop rule regarding instance variables in specs
* some repair to csv_importer to properly work with the PFCollection
objects in the graph
