### PR TITLE
Remove invalid Job actions and routes

### DIFF
--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -19,49 +19,6 @@ class JobsController < ApplicationController
     @job = Job.new
   end
 
-  # GET /jobs/1/edit
-  def edit
-  end
-
-  # POST /jobs or /jobs.json
-  def create
-    @job = Job.new(job_params)
-    @job.user = current_user
-    @job.completed_at = nil
-
-    respond_to do |format|
-      if @job.save
-        format.html { redirect_to @job, notice: "Job was successfully created." }
-        format.json { render :show, status: :created, location: @job }
-      else
-        format.html { render :new, status: :unprocessable_entity }
-        format.json { render json: @job.errors, status: :unprocessable_entity }
-      end
-    end
-  end
-
-  # PATCH/PUT /jobs/1 or /jobs/1.json
-  def update
-    respond_to do |format|
-      if @job.update(job_params)
-        format.html { redirect_to @job, notice: "Job was successfully updated." }
-        format.json { render :show, status: :ok, location: @job }
-      else
-        format.html { render :edit, status: :unprocessable_entity }
-        format.json { render json: @job.errors, status: :unprocessable_entity }
-      end
-    end
-  end
-
-  # DELETE /jobs/1 or /jobs/1.json
-  def destroy
-    @job.destroy
-    respond_to do |format|
-      format.html { redirect_to jobs_url, notice: "Job was successfully destroyed." }
-      format.json { head :no_content }
-    end
-  end
-
   private
 
   def ensure_admin!

--- a/app/views/jobs/show.html.erb
+++ b/app/views/jobs/show.html.erb
@@ -38,5 +38,5 @@
   <%= @job.files %>
 </p>
 
-<%= link_to 'Edit', edit_job_path(@job) %> |
+<%# link_to 'Edit', edit_job_path(@job) %> |
 <%= link_to 'Back', jobs_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@
 require 'sidekiq/web'
 Rails.application.routes.draw do
   resource :theme, only: [:edit, :update]
-  resources :jobs
+  resources :jobs,       only: [:index, :new, :show]
   resources :preflights, only: [:index, :new, :create, :show]
 
   resource :dashboard, only: [:show], controller: 'tenejo/dashboard' do

--- a/spec/requests/jobs_spec.rb
+++ b/spec/requests/jobs_spec.rb
@@ -26,10 +26,6 @@ RSpec.describe "/jobs", type: :request do
       files: 4 }
   }
 
-  let(:invalid_attributes) {
-    skip("Add a hash of attributes invalid for your model")
-  }
-
   let(:admin) { User.create(email: 'test@example.com', password: '123456', roles: [Role.create(name: 'admin')]) }
 
   before do
@@ -68,96 +64,6 @@ RSpec.describe "/jobs", type: :request do
     it "renders a successful response" do
       get new_job_url
       expect(response).to be_successful
-    end
-  end
-
-  describe "GET /edit" do
-    it "render a successful response" do
-      job = Job.create! valid_attributes
-      get edit_job_url(job)
-      expect(response).to be_successful
-    end
-  end
-
-  describe "POST /create" do
-    context "with valid parameters" do
-      it "creates a new Job" do
-        expect {
-          post jobs_url, params: { job: valid_attributes }
-        }.to change(Job, :count).by(1)
-      end
-
-      it "redirects to the created job" do
-        post jobs_url, params: { job: valid_attributes }
-        expect(response).to redirect_to(job_url(Job.last))
-      end
-    end
-
-    context "with invalid parameters" do
-      it "does not create a new Job" do
-        expect {
-          post jobs_url, params: { job: invalid_attributes }
-        }.to change(Job, :count).by(0)
-      end
-
-      it "renders a successful response (i.e. to display the 'new' template)" do
-        post jobs_url, params: { job: invalid_attributes }
-        expect(response).to be_successful
-      end
-    end
-  end
-
-  describe "PATCH /update" do
-    context "with valid parameters" do
-      let(:new_attributes) {
-        { type: nil,
-          label: "Label",
-          status: "Completed",
-          completed_at: completion_time,
-          collections: 7,
-          works: 11,
-          files: 17 }
-      }
-      let(:completion_time) { Time.current.round }
-
-      it "updates the requested job" do
-        job = Job.create! valid_attributes
-        patch job_url(job), params: { job: new_attributes }
-        job.reload
-        expect(job.completed_at).to eq completion_time
-        expect(job.status).to eq 'Completed'
-        expect(job.files).to eq 17
-      end
-
-      it "redirects to the job" do
-        job = Job.create! valid_attributes
-        patch job_url(job), params: { job: new_attributes }
-        job.reload
-        expect(response).to redirect_to(job_url(job))
-      end
-    end
-
-    context "with invalid parameters" do
-      it "renders a successful response (i.e. to display the 'edit' template)" do
-        job = Job.create! valid_attributes
-        patch job_url(job), params: { job: invalid_attributes }
-        expect(response).to be_successful
-      end
-    end
-  end
-
-  describe "DELETE /destroy" do
-    it "destroys the requested job" do
-      job = Job.create! valid_attributes
-      expect {
-        delete job_url(job)
-      }.to change(Job, :count).by(-1)
-    end
-
-    it "redirects to the jobs list" do
-      job = Job.create! valid_attributes
-      delete job_url(job)
-      expect(response).to redirect_to(jobs_url)
     end
   end
 end

--- a/spec/routing/jobs_routing_spec.rb
+++ b/spec/routing/jobs_routing_spec.rb
@@ -14,25 +14,29 @@ RSpec.describe JobsController, type: :routing do
     it "routes to #show" do
       expect(get: "/jobs/1").to route_to("jobs#show", id: "1")
     end
+  end
 
+  # Only job subclasses should be persisted to the database and
+  # Jobs are not currently modifiable via the UI after creation
+  describe "invalid routes" do
     it "routes to #edit" do
-      expect(get: "/jobs/1/edit").to route_to("jobs#edit", id: "1")
+      expect(get: "/jobs/1/edit").not_to be_routable
     end
 
     it "routes to #create" do
-      expect(post: "/jobs").to route_to("jobs#create")
+      expect(post: "/jobs").not_to be_routable
     end
 
     it "routes to #update via PUT" do
-      expect(put: "/jobs/1").to route_to("jobs#update", id: "1")
+      expect(put: "/jobs/1").not_to be_routable
     end
 
     it "routes to #update via PATCH" do
-      expect(patch: "/jobs/1").to route_to("jobs#update", id: "1")
+      expect(patch: "/jobs/1").not_to be_routable
     end
 
     it "routes to #destroy" do
-      expect(delete: "/jobs/1").to route_to("jobs#destroy", id: "1")
+      expect(delete: "/jobs/1").not_to be_routable
     end
   end
 end


### PR DESCRIPTION
Job is the parent class to a variety of subclasses to support
various batch processes that we want to run in the background.

Records from the parent class should not be persisted in the database
so we don't support routes for :create, :edit, :update, or :destroy actions.