### PR TITLE
Rename IngestJob class to avoid conflict with Hyrax

### DIFF
--- a/app/jobs/batch_import_job.rb
+++ b/app/jobs/batch_import_job.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
-require 'tenejo/preflight'
-require 'tenejo/csv_importer'
-class IngestJob < ApplicationJob
+class BatchImportJob < ApplicationJob
   queue_as :default
 
   def perform(filename)

--- a/spec/jobs/batch_import_job_spec.rb
+++ b/spec/jobs/batch_import_job_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.describe IngestJob, type: :job do
+RSpec.describe BatchImportJob, type: :job do
   describe "#perform_later" do
     it "queues" do
       ActiveJob::Base.queue_adapter = :test


### PR DESCRIPTION
Hyrax has an InjestJob class that is not namespaced to Hyrax and
the class in the PR was inadvertently overriding part of the code
Hyrax uses to upload works from the UI.

It seemed more expedient to rename our Job that to try to implement
better namespacing of the class in Hyrax.

See https://github.com/samvera/hyrax/blob/main/app/jobs/ingest_job.rb

Fixes the error seen here:
![image](https://user-images.githubusercontent.com/3064318/144728665-6cbbc460-64bc-4346-b57d-aeadfb6c4108.png)
