### PR TITLE
Add an Import model to the application

### DIFF
--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+class Import < Job
+  delegate :manifest, to: :parent_job
+end

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
 class Job < ApplicationRecord
   belongs_to :user
+
+  has_many :child_jobs, class_name: 'Job', foreign_key: 'parent_job_id', dependent: :nullify
+  belongs_to :parent_job, class_name: 'Job', optional: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class User < ApplicationRecord
+  has_many :jobs, dependent: :restrict_with_error
+
   # Connects this user object to Hydra behaviors.
   include Hydra::User
   # Connects this user object to Role-management behaviors.

--- a/db/migrate/20211205193250_add_parent_job_ref_to_jobs.rb
+++ b/db/migrate/20211205193250_add_parent_job_ref_to_jobs.rb
@@ -1,0 +1,5 @@
+class AddParentJobRefToJobs < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :jobs, :parent_job, foreign_key: { to_table: :jobs }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_29_173942) do
+ActiveRecord::Schema.define(version: 2021_12_05_193250) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -192,7 +192,9 @@ ActiveRecord::Schema.define(version: 2021_11_29_173942) do
     t.integer "files"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "parent_job_id"
     t.index ["completed_at"], name: "index_jobs_on_completed_at"
+    t.index ["parent_job_id"], name: "index_jobs_on_parent_job_id"
     t.index ["status"], name: "index_jobs_on_status"
     t.index ["type"], name: "index_jobs_on_type"
     t.index ["user_id"], name: "index_jobs_on_user_id"
@@ -628,6 +630,7 @@ ActiveRecord::Schema.define(version: 2021_11_29_173942) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "collection_type_participants", "hyrax_collection_types"
   add_foreign_key "curation_concerns_operations", "users"
+  add_foreign_key "jobs", "jobs", column: "parent_job_id"
   add_foreign_key "jobs", "users"
   add_foreign_key "mailboxer_conversation_opt_outs", "mailboxer_conversations", column: "conversation_id", name: "mb_opt_outs_on_conversations_id"
   add_foreign_key "mailboxer_notifications", "mailboxer_conversations", column: "conversation_id", name: "notifications_on_conversation_id"

--- a/spec/models/import_spec.rb
+++ b/spec/models/import_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Import, type: :model do
+  context ".manifest" do
+    it 'delegates to the parent_job' do
+      job = described_class.new(parent_job: Preflight.new)
+      expect(job.manifest.class).to eq ActiveStorage::Attached::One
+      expect(job.manifest).not_to be_attached
+    end
+
+    it "raises an error when no parent is set" do
+      job = described_class.new
+      expect { job.manifest }.to raise_error(NoMethodError)
+    end
+
+    it "raises an error when the parent class doesn't implement .manifest" do
+      job = described_class.new(parent_job: Job.new)
+      expect { job.manifest }.to raise_error(NoMethodError)
+    end
+  end
+end

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -20,4 +20,12 @@ RSpec.describe Job, type: :model do
     job.reload
     expect(job.user).to eq user
   end
+
+  it 'has an optional parent_job' do
+    job1 = described_class.new(user: user)
+    job2 = described_class.new(user: user)
+    job2.parent_job = job1
+    job2.save!
+    expect(job1.child_jobs).to include job2
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  let!(:user) { described_class.create(email: 'teat1234@example.com', password: '654321') }
+  let!(:job) { Job.create(user: user) }
+
+  it 'can have associated jobs', :aggregate_failures do
+    expect(user.jobs).to include job
+    expect(job.user).to eq user
+  end
+
+  it 'is protected from deletion if the user has jobs', :aggregate_failures do
+    expect { user.destroy! }.to raise_exception(ActiveRecord::RecordNotDestroyed)
+    expect(user.errors.messages[:base]).to include('Cannot delete record because dependent jobs exist')
+  end
+end


### PR DESCRIPTION
Adding an `Import` class which inherits from the `Job` class to support
tracking and displaying status of background csv import jobs.

* Each instance can point to a `parent_job`, typically an associated Preflight
* Delegates access to the manifest in the `parent_job`
* Clarifies the two-way relationships between users and jobs
    * Every job must have a user associated
    * A user may have 0 or more jobs associated
    * Don't delete users if they have jobs associated