### PR TITLE
Add an Import Job type

### DIFF
--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+class ImportsController < JobsController
+  with_themed_layout 'dashboard'
+
+  def index
+    redirect_to jobs_path
+  end
+
+  def new
+    redirect_to new_preflight_path
+  end
+
+  def create
+    @job = Import.new(job_params)
+    @job.user = current_user
+
+    respond_to do |format|
+      if @job.save
+        BatchImportJob.perform_later(@job)
+        format.html { redirect_to @job, notice: "Job was successfully created." }
+        format.json { render :show, status: :created, location: @job }
+      end
+    end
+  end
+
+  private
+
+  # Only allow a list of trusted parameters through.
+  def job_params
+    params.require(:import).permit(:parent_job_id)
+  end
+end

--- a/app/jobs/batch_import_job.rb
+++ b/app/jobs/batch_import_job.rb
@@ -2,9 +2,9 @@
 class BatchImportJob < ApplicationJob
   queue_as :default
 
-  def perform(filename)
+  def perform(import_job)
     # probably not optimal, but enough until we get
     # import hammered out
-    Tenejo::CsvImporter.import(Tenejo::Preflight.process_csv(File.open(filename)))
+    Tenejo::CsvImporter.new(import_job).import
   end
 end

--- a/app/lib/tenejo/csv_importer.rb
+++ b/app/lib/tenejo/csv_importer.rb
@@ -2,56 +2,109 @@
 
 module Tenejo
   class CsvImporter
-    COLLECTION_PROPERTIES = [
-      'abstract',
-      'access_right',
-      'alternative_title',
-      'based_near',
-      'bibliographic_citation',
-      # 'collection_type_gid',
-      'contributor',
-      'create_date',
-      'creator',
-      'date_created',
-      # 'date_modified',
-      # 'date_uploaded',
-      'depositor',
-      'description',
-      # 'has_model',
-      # 'head',
-      'identifier',
-      # 'import_url',
-      'keyword',
-      'label',
-      'language',
-      'license',
-      'modified_date',
-      'publisher',
-      'related_url',
-      'relative_path',
-      'resource_type',
-      'rights_notes',
-      'rights_statement',
-      'source',
-      'subject',
-      # 'tail',
-      'title'
-    ].freeze
+    def initialize(import_job)
+      @job = import_job
+      @graph = Tenejo::Preflight.process_csv(import_job.manifest.download)
+      @depositor = import_job.user.user_key
+    end
 
-    def self.import(graph)
-      default_collection_type = Hyrax::CollectionType.find_or_create_default_collection_type
+    def import
+      return if fatal_errors(@graph)
+      make_collections(@graph)
+      make_works(@graph)
+      make_files(@graph)
+    end
 
-      graph[:collection].each do |collection_params|
-        begin
-          collection = Collection.find(collection_params.identifier)
-        rescue ActiveFedora::ObjectNotFoundError
-          collection = Collection.new(id: collection_params.identifier, collection_type_gid: default_collection_type.gid)
-        end
-        collection.title = [collection_params.title]
-        collection.description = collection_params.description # is description really a column?
-        collection.date_modified = collection.date_uploaded = Time.current
-        collection.save!
+    def fatal_errors(graph)
+      graph[:fatal_errors]&.any?
+    end
+
+    def job_owner
+      @depositor
+    end
+
+    def make_collections(graph)
+      graph[:collection].each do |pfcollection|
+        create_or_update_collection(pfcollection)
       end
+    end
+
+    def create_or_update_collection(pfcollection)
+      # put all the expensive stuff here
+      # and unit test the heck out of it
+      collection = find_or_new_collection(pfcollection.identifier, pfcollection.title)
+      update_collection_attributes(collection, pfcollection)
+      save_collection(collection)
+    end
+
+    # Finds or creates a job by it's user supplied identifier
+    # returns a valid collection or nil
+    def find_or_new_collection(primary_id, title)
+      collection_found = Collection.where(identifier: primary_id).last
+      return collection_found if collection_found
+      Collection.new(
+        identifier: primary_id,
+        title: title,
+        depositor: job_owner,
+        collection_type_gid: Tenejo::CsvImporter.default_collection_type
+      )
+    end
+
+    def update_collection_attributes(collection, pfcollection)
+      return unless collection
+      attributes_to_copy.each { |source, dest| collection.send(dest, pfcollection.send(source)) }
+      # set the parent collection
+      # these timestamps are the Hyrax managed fields, not rails timestamps
+      if collection.date_uploaded
+        collection.date_modified = Time.current
+      else
+        collection.date_uploaded = Time.current
+      end
+      collection.depositor ||= job_owner
+    end
+
+    def save_collection(collection)
+      return unless collection
+      begin
+        collection.save!
+        # update job status table - collection creation successful
+      rescue
+        # update job status table - collection creation failed - save error to table
+      end
+    end
+
+    def make_works(graph)
+      graph[:work].each do |pfwork|
+        create_or_update_work(pfwork)
+      end
+    end
+
+    def create_or_update_work(pfwork)
+      # expensive stuff here
+    end
+
+    def make_files(graph)
+      graph[:file].each do |pffile|
+        create_or_update_file(pffile)
+      end
+    end
+
+    def create_or_update_file(pffile)
+      # expensive stuff here
+    end
+
+    def self.default_collection_type
+      @default_collection_type ||= Hyrax::CollectionType.find_or_create_default_collection_type
+    end
+
+    def attributes_to_copy
+      @attributes_to_copy ||=
+        ((Collection.terms & Tenejo::PFCollection::ALL_FIELDS) - fields_to_exclude
+        ).map { |key| [key, "#{key}=".to_sym] }.to_h
+    end
+
+    def fields_to_exclude
+      [:collection_type_gid, :depositor, :has_model, :date_uploaded, :create_date, :modified_date, :head, :tail]
     end
   end
 end

--- a/app/lib/tenejo/preflight.rb
+++ b/app/lib/tenejo/preflight.rb
@@ -164,6 +164,7 @@ module Tenejo
     end
 
     def self.process_csv(input, import_path = DEFAULT_UPLOAD_PATH)
+      return { fatal_errors: "No manifest present" } unless input
       begin
         csv = CSV.new(input, headers: true, return_headers: true, skip_blanks: true,
                       header_converters: [->(m) { map_header(m) }])

--- a/app/views/jobs/index.html.erb
+++ b/app/views/jobs/index.html.erb
@@ -1,6 +1,7 @@
 <p id="notice"><%= notice %></p>
 
 <h1>Jobs</h1>
+<%= link_to 'New Job', new_job_path, class: 'btn btn-primary' %>
 
 <table id=jobs-index>
   <thead>
@@ -35,7 +36,3 @@
     <% end %>
   </tbody>
 </table>
-
-<br>
-
-<%= link_to 'New Job', new_job_path %>

--- a/app/views/preflights/show.html.erb
+++ b/app/views/preflights/show.html.erb
@@ -13,7 +13,7 @@
 
 <div id="preflight-manifest"><p>
   <strong>File:</strong>
-  <% if @job&.manifest&.filename %>
+  <% if @job&.manifest&.attached? %>
     <%= link_to(@job.manifest.filename, rails_blob_path(@job.manifest, disposition: 'attachment')) %>
   <% else %>
     --
@@ -50,7 +50,17 @@
   <%= @job&.files || '--' %>
 </p></div>
 
-<%= link_to 'Back', jobs_path %>
+<%= link_to 'Back', jobs_path, class: 'btn btn-default' %>
+
+<%# IMPORT SUBMISSION FORM %>
+<% if @preflight_graph[:fatal_errors]&.empty? %>
+  <%= form_with(model: Import, local: true) do |form| %>
+    <%= form.hidden_field :parent_job_id, value: @job.id %>
+    <div class="actions">
+      <%= form.submit 'Start Import', type: 'submit', class: 'btn btn-primary' %>
+    </div>
+  <% end %>
+<% end %>
 
 <h2>Analysis</h2>
 
@@ -173,7 +183,7 @@
 
 <%# RAW GRAPH %>
 <p>
-  <button class="btn btn-primary" type="button" data-toggle="collapse" data-target="#rawPreflight" aria-expanded="false" aria-controls="rawPreflight">
+  <button class="btn btn-info" type="button" data-toggle="collapse" data-target="#rawPreflight" aria-expanded="false" aria-controls="rawPreflight">
     Show raw preflight
   </button>
 </p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   resource :theme, only: [:edit, :update]
   resources :jobs,       only: [:index, :new, :show]
   resources :preflights, only: [:index, :new, :create, :show]
+  resources :imports,    only: [:index, :new, :create, :show]
 
   resource :dashboard, only: [:show], controller: 'tenejo/dashboard' do
     collection do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 FactoryBot.define do
   factory :user do
-    email { "user@example.com" }
+    sequence(:email) { |n| "user#{n}@example.com" }
     password { "somepassword" }
-    password_confirmation { "somepassword" }
     trait :admin do
       roles { [association(:role, name: 'admin')] }
     end

--- a/spec/jobs/batch_import_job_spec.rb
+++ b/spec/jobs/batch_import_job_spec.rb
@@ -2,6 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe BatchImportJob, type: :job do
+  let(:user) { FactoryBot.create(:user) }
   describe "#perform_later" do
     it "queues" do
       ActiveJob::Base.queue_adapter = :test
@@ -9,12 +10,15 @@ RSpec.describe BatchImportJob, type: :job do
         described_class.perform_later("filename")
       } .to have_enqueued_job.with("filename").on_queue(:default)
     end
-    it "calls the importer with a graph made from a file" do
+
+    # rubocop:disable RSpec/MessageChain
+    it "calls the importer with a graph made from a job" do
+      # This test creates a fake preflight error which causes the fastest possible import
       ActiveJob::Base.queue_adapter = :test
-      allow(Tenejo::CsvImporter).to receive(:import)
-      allow(Tenejo::Preflight).to receive(:process_csv).and_return "some graph"
-      described_class.perform_now(Rails.root.join("spec/fixtures/csv/fancy.csv"))
-      expect(Tenejo::CsvImporter).to have_received(:import).with("some graph")
+      import_job = Import.create!(user: user)
+      allow(import_job).to receive_message_chain('manifest.download') { 'csv placeholder' }
+      allow(Tenejo::Preflight).to receive(:process_csv).and_return({ fatal_errors: ['No data was detected'] })
+      described_class.perform_now(import_job)
       expect(Tenejo::Preflight).to have_received(:process_csv)
     end
   end

--- a/spec/lib/tenejo/csv_importer_spec.rb
+++ b/spec/lib/tenejo/csv_importer_spec.rb
@@ -1,36 +1,127 @@
 # frozen_string_literal: true
-# require './app/lib/tenejo/csv_importer'
 require 'rails_helper'
 
-# rubocop:disable RSpec/InstanceVariable
 RSpec.describe Tenejo::CsvImporter do
-  before :context do
-    graph = Tenejo::Preflight.read_csv(File.open("./spec/fixtures/csv/fancy.csv"))
-    @fixture = graph[:collection].find { |x| x.identifier == "TESTINGCOLLECTION" }
-    @fixture.identifier = Time.now.to_i.to_s # make sort of unique identifier
-    described_class.import(graph)
-    @persisted = Collection.find(@fixture.identifier)
-  end
-  after :context do
-    @persisted.delete
-  end
-  it 'creates a persistent collection' do
-    expect(@persisted).not_to be_nil
+  let(:job_owner) { FactoryBot.create(:user) }
+  let(:csv) { fixture_file_upload("./spec/fixtures/csv/fancy.csv") }
+  let(:preflight) { Preflight.create!(user: job_owner, manifest: csv) }
+  let(:import_job)  { Import.create!(user: job_owner, parent_job: preflight) }
+
+  context "with fatal errors" do
+    let(:csv) { fixture_file_upload("./spec/fixtures/csv/empty.csv") }
+    # rubocop:disable RSpec/MessageSpies
+    it "creates no objects" do
+      csv_import = described_class.new(import_job)
+      expect(csv_import).not_to receive(:make_collections)
+      expect(csv_import).not_to receive(:make_works)
+      expect(csv_import).not_to receive(:make_files)
+      csv_import.import
+    end
   end
 
-  it 'creates collections with expected identifiers' do
-    expect(@persisted.id).to eq @fixture.identifier
+  it 'calls modules', :aggregate_failures do
+    csv_import = described_class.new(import_job)
+    allow(csv_import).to receive(:create_or_update_collection)
+    allow(csv_import).to receive(:create_or_update_work)
+    allow(csv_import).to receive(:create_or_update_file)
+
+    csv_import.import
+
+    expect(csv_import).to have_received(:create_or_update_collection).exactly(2).times
+    expect(csv_import).to have_received(:create_or_update_work).exactly(4).times
+    expect(csv_import).to have_received(:create_or_update_file).exactly(4).times
   end
 
-  it 'sets #date_uploaded' do
-    expect(@persisted.date_uploaded.in_time_zone).to be_within(1.minute).of(Time.current)
-  end
+  context '.create_or_update_collection' do
+    before { allow(Tenejo::Preflight).to receive(:process_csv) } # skip creating the preflight graph
 
-  it 'sets #date_modified to #date_uploaded' do
-    expect(@persisted.date_modified).to eq @persisted.date_uploaded
-  end
+    context "collection with identifier not found" do
+      # these tests are expensive, try to minimize how many we need to run
+      before do
+        # Ensure a collection with the expected :identifier does not exist
+        Collection.where(identifier: 'TEST0001').to_a.each { |c| c.destroy(eradicate: true) }
+      end
+      let(:pf_collection) { Tenejo::PFCollection.new({ identifier: ['TEST0001'], title: ['Importer test collection'] }, -1) }
 
-  it 'saves titles' do
-    expect(Collection.where(title: 'The testing collection').count).to be >= 1
+      it "creates a new collection", :aggregate_failures do
+        csv_import = described_class.new(import_job)
+        expect { csv_import.create_or_update_collection(pf_collection) }.to change { Collection.where(identifier: 'TEST0001').count }.from(0).to(1)
+        collection = Collection.where(identifier: 'TEST0001').last
+        expect(collection.depositor).to eq job_owner.user_key
+        expect(collection.date_uploaded.in_time_zone).to be_within(1.minute).of Time.current
+        expect(collection.title).to eq pf_collection.title
+      end
+    end
+
+    context "with pre-existing collections" do
+      before(:context) do
+        # Ensure a collection with the expected :identifier exists -> 'TEST0002'
+        collection =
+          Collection.new(
+            identifier: ['TEST0002'],
+            title: ['Importer test collection'],
+            date_uploaded: '2020-07-01 12:30:05',
+            collection_type_gid: described_class.default_collection_type
+          )
+        begin
+          collection.save!
+        rescue Ldp::Conflict
+          collection.save! # I know this seems ridiculous, but tests were flaky otherwise...
+        end
+      end
+      let(:pf_collection) { Tenejo::PFCollection.new({ identifier: ['TEST0002'], title: ['Importer test collection'] }, -1) }
+
+      after(:context) do
+        Collection.where(identifier: 'TEST0002').to_a.each { |c| c.destroy(eradicate: true) }
+      end
+
+      it "uses the existing collection instead of creating a new one" do
+        csv_import = described_class.new(import_job)
+        expect { csv_import.create_or_update_collection(pf_collection) }.not_to change { Collection.where(identifier: 'TEST0002').count }
+      end
+
+      it "sets administrative data", :aggregate_failures do
+        csv_import = described_class.new(import_job)
+        csv_import.create_or_update_collection(pf_collection)
+        collection = Collection.where(identifier: 'TEST0002').last
+        expect(collection.depositor).not_to be_nil
+        expect(collection.date_uploaded).to eq '2020-07-01 12:30:05' # should not be changed
+        expect(collection.date_modified.in_time_zone).to be_within(1.minute).of Time.current
+      end
+
+      context 'with all the values' do
+        let(:settable_attributes) {
+          { "identifier" => ["TEST0002"], "title" => ["Snappy title"], "alternative_title" => ["The other title"],
+          "label" => "Not a real title", "relative_path" => "path/to/file.ext", "import_url" => "https:://localhost:3000/import",
+          "resource_type" => ["Image"], "creator" => ["c1"], "contributor" => ["c2"], "description" => ["a test fixture"],
+          "abstract" => ["used for tests"], "keyword" => ["none"], "license" => ["http://creativecommons.org/publicdomain/mark/1.0/"],
+          "rights_notes" => ["use freely"], "rights_statement" => ["http://rightsstatements.org/vocab/CNE/1.0/"],
+          "access_right" => ["free to use"], "publisher" => ["DCE"], "date_created" => ["2021-12-06"], "subject" => ["tbd"],
+          "language" => ["english"], "based_near" => [], "related_url" => ["/also/#"], "bibliographic_citation" => ["yada yada"], "source" => ["mhb"] }
+        }
+        let(:fixed_attributes) {
+          { "id" => "fake0id", "depositor" => "fake_admin@example.org", "date_uploaded" => "2021-01-01 00:00:01",
+          "date_modified" => nil, "head" => ['invalid value'], "tail" => ['invalid value'], "collection_type_gid" => "invalid_value", "has_model" => "european" }
+        }
+        let(:all_attributes) { settable_attributes.merge(fixed_attributes) }
+        let(:pf_collection) { Tenejo::PFCollection.new(all_attributes, -1) }
+
+        it "updates all of them", :aggregate_failures do
+          csv_import = described_class.new(import_job)
+          csv_import.create_or_update_collection(pf_collection)
+          collection = Collection.where(identifier: 'TEST0002').last
+
+          # Most settings should be updated by the import
+          expect(collection.attributes).to include settable_attributes
+
+          # A handful of values should not have been modified even if they were in the preflight
+          expect(collection.id).not_to eq "fake0id"
+          expect(collection.depositor).not_to be_nil
+          expect(collection.depositor).not_to eq "fake_admin@example.org"
+          expect(collection.date_uploaded).to eq '2020-07-01 12:30:05' # should not change to 2021-01-01
+          expect(collection.date_modified.in_time_zone).to be_within(1.minute).of Time.current
+        end
+      end
+    end
   end
 end

--- a/spec/lib/tenejo/preflight_spec.rb
+++ b/spec/lib/tenejo/preflight_spec.rb
@@ -10,6 +10,14 @@ RSpec.describe Tenejo::Preflight do
   after :all do
     FileUtils.rm_r("tmp/uploads")
   end
+
+  context '.process_csv' do
+    let(:no_data) { described_class.process_csv(nil, nil) }
+    it 'returns an error when input stream absent' do
+      expect(no_data[:fatal_errors]).to include "No manifest present"
+    end
+  end
+
   context "a file with duplicate columns" do
     let(:dupes) { described_class.read_csv("spec/fixtures/csv/dupe_col.csv", "tmp/uploads") }
 
@@ -183,6 +191,7 @@ RSpec.describe Tenejo::Preflight do
       expect(p.last.file).to eq "c"
     end
   end
+
   describe Tenejo::PFCollection do
     let(:rec) { described_class.new({}, 1) }
     it "is not valid when blank" do

--- a/spec/requests/import_request_spec.rb
+++ b/spec/requests/import_request_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe "/imports", type: :request do
+  let(:tempfile) { fixture_file_upload('csv/empty.csv') }
+  let(:admin) { User.create(email: 'test@example.com', password: '123456', roles: [Role.create(name: 'admin')]) }
+  let(:preflight) { Preflight.new(user: admin, manifest: tempfile) }
+  let(:import) { Import.new(user: admin, parent_job: preflight) }
+
+  before do
+    sign_in admin
+  end
+
+  describe "GET /index" do
+    it "redirects to /jobs/index" do
+      get imports_path
+      expect(response).to redirect_to jobs_path
+    end
+  end
+
+  describe "GET /new" do
+    it "redirects to /preflights/new" do
+      get new_import_path
+      expect(response).to redirect_to new_preflight_path
+    end
+  end
+
+  describe "GET /show" do
+    it "displays info for an Import job" do
+      import.save!
+      get import_path import
+      expect(response).to render_template('imports/show')
+    end
+  end
+
+  describe "POST /create" do
+    it "creates a new Import job" do
+      expect {
+        post imports_path, params: { import: { parent_job_id: preflight.id } }
+      }.to change(Import, :count).by(1)
+    end
+
+    it "queues a new IngestJob" do
+      ActiveJob::Base.queue_adapter = :test
+      expect {
+        post imports_path, params: { import: { parent_job_id: preflight.id } }
+      } .to enqueue_job(BatchImportJob).with(Job.last).on_queue(:default)
+    end
+
+    it "redirects to the submitted Import show view" do
+      post imports_path, params: { import: { parent_job_id: preflight.id } }
+      expect(response).to redirect_to Import.last
+    end
+  end
+end

--- a/spec/routing/imports_routing_spec.rb
+++ b/spec/routing/imports_routing_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe ImportsController, type: :routing do
+  describe "routing" do
+    it "routes to #index" do
+      expect(get: "/imports").to route_to("imports#index")
+    end
+
+    it "routes to #new" do
+      expect(get: "/imports/new").to route_to("imports#new")
+    end
+
+    it "routes to #show" do
+      expect(get: "/imports/1").to route_to("imports#show", id: "1")
+    end
+
+    it "routes to #create" do
+      expect(post: "/imports").to route_to("imports#create")
+    end
+
+    # Preflight jobs are not editable after creation
+    context 'invalid routes' do
+      it "does not route to #edit" do
+        expect(get: "/imports/1/edit").not_to be_routable
+      end
+
+      it "does not route to #update via PUT" do
+        expect(put: "/imports/1").not_to be_routable
+      end
+
+      it "does not route to #update via PATCH" do
+        expect(patch: "/imports/1").not_to be_routable
+      end
+
+      it "does not route to #destroy" do
+        expect(delete: "/imports/1").not_to be_routable
+      end
+    end
+  end
+end

--- a/spec/views/preflights/show.html.erb_spec.rb
+++ b/spec/views/preflights/show.html.erb_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "preflights/show", type: :view do
   let(:completion_time) { Time.current.round }
   let(:job) {
     Preflight.new(
+      id: 8_675_309,
       user: user,
       manifest: tempfile,
       status: :completed,
@@ -29,6 +30,24 @@ RSpec.describe "preflights/show", type: :view do
     expect(rendered).to have_selector('#preflight-works', text: '13')
     expect(rendered).to have_selector('#preflight-files', text: '17')
     expect(rendered).to have_link(text: 'empty.csv')
+  end
+
+  context "provides a 'Start Import' button" do
+    it "with a valid Preflight ID", :aggregate_failures do
+      @job = job
+      @preflight_graph = { fatal_errors: [] }
+      render
+      expect(rendered).to have_button('Start Import', type: 'submit')
+      assert_select 'input[id="import_parent_job_id"][value="8675309"]'
+      assert_select 'form[action=?][method=?]', imports_path, 'post'
+    end
+
+    it "except when there are preflight errors" do
+      @job = job
+      @preflight_graph = { fatal_errors: ["No data was detected"] }
+      render
+      expect(rendered).to have_no_button('Start Import', type: 'submit')
+    end
   end
 
   it "handles missing attributes gracefully" do


### PR DESCRIPTION
Imports allow the user to run an import based on the CSV from a
previous preflight.  The import will run in the background and
(eventually) provide status reporting back via the Import job class.

* When a preflight runs without fatal errors, allow the user to submit
it's CSV for import in the background
* Associate the `Import` with the `Preflight` so they can share the CSV
the user uploaded for preflight
* Run the import in the background
* Ccreate the collections in the CSV
* TODO: create works, and files
* TODO: provide status reporting as the job progresses