### PR TITLE
Allow theme changes to be applied sitewide

### DIFF
--- a/app/controllers/themes_controller.rb
+++ b/app/controllers/themes_controller.rb
@@ -40,19 +40,18 @@ class ThemesController < ApplicationController
 
   # PATCH/PUT /themes/1 or /themes/1.json
   def update
-    if params[:apply]
-      appearance.header_background_color = @theme.primary_color
-    else
-      params[:theme] = Theme::DEFAULTS if params[:reset]
-      theme.logo.attach(params[:theme][:logo]) if params[:theme][:logo]
-      if @theme.update(theme_params)
-        redirect_to edit_theme_path
-      else
-        render edit_theme_path, status: :unprocessable_entity
-      end
+    if params[:reset] == "true"
+      params[:theme] = Theme::DEFAULTS
+      @theme.logo.purge
     end
-    
 
+    if @theme.update(theme_params)
+      redirect_to edit_theme_path
+    else
+      render edit_theme_path, status: :unprocessable_entity
+    end
+
+    apply_theme_to_site if params[:apply] == "true"
   end
 
   # DELETE /themes/1 or /themes/1.json
@@ -80,5 +79,19 @@ class ThemesController < ApplicationController
   # Restrict theme access to admins
   def ensure_admin!
     authorize! :read, :admin_dashboard
+  end
+
+  def apply_theme_to_site
+    theme = Theme.current_theme
+    appearance_to_theme_mapping = {
+      header_background_color:          theme.primary_color,
+      header_text_color:                theme.primary_text_color,
+      link_color:                       theme.accent_text_color,
+      footer_link_color:                theme.accent_text_color,
+      primary_button_background_color:  theme.primary_color
+    }
+    appearance_to_theme_mapping.each do |appearance_color, theme_color|
+      ContentBlock.find_or_create_by(name: appearance_color).update!(value: theme_color)
+    end
   end
 end

--- a/app/controllers/themes_controller.rb
+++ b/app/controllers/themes_controller.rb
@@ -40,13 +40,19 @@ class ThemesController < ApplicationController
 
   # PATCH/PUT /themes/1 or /themes/1.json
   def update
-    params[:theme] = Theme::DEFAULTS if params[:reset]
-    theme.logo.attach(params[:theme][:logo]) if params[:theme][:logo]
-    if @theme.update(theme_params)
-      redirect_to edit_theme_path
+    if params[:apply]
+      appearance.header_background_color = @theme.primary_color
     else
-      render edit_theme_path, status: :unprocessable_entity
+      params[:theme] = Theme::DEFAULTS if params[:reset]
+      theme.logo.attach(params[:theme][:logo]) if params[:theme][:logo]
+      if @theme.update(theme_params)
+        redirect_to edit_theme_path
+      else
+        render edit_theme_path, status: :unprocessable_entity
+      end
     end
+    
+
   end
 
   # DELETE /themes/1 or /themes/1.json

--- a/app/views/themes/_form.html.erb
+++ b/app/views/themes/_form.html.erb
@@ -70,9 +70,11 @@
   <hr/>
   <div class="actions">
     <%= form.submit 'Preview Changes', name: 'save', class: 'btn btn-primary btn-block' %>
-    <%= form.submit 'Apply Changes', name: 'save', class: 'btn btn-danger btn-block'%>
-
-    <%= button_tag(name: 'reset', class: 'btn btn-default btn-block', "data-loading-text":"Loading...") do %>
+    <%= button_tag(name: 'apply', class: 'btn btn-danger btn-block') do %>
+      <span class="glyphicon glyphicon-tint" aria-hidden="true"></span> Apply Changes
+    <% end %>
+   
+    <%= button_tag(name: 'reset', class: 'btn btn-default btn-block') do %>
       <span class="glyphicon glyphicon-refresh" aria-hidden="true"></span> Reset to Defaults
     <% end %>
 </div><% end %>

--- a/app/views/themes/_form.html.erb
+++ b/app/views/themes/_form.html.erb
@@ -69,7 +69,10 @@
 
   <hr/>
   <div class="actions">
-    <%= form.submit 'Save Changes', name: 'save', class: 'btn btn-primary' %>
-    <%= form.submit 'Reset to Defaults', name: 'reset', class: 'btn btn-default' %>
-  </div>
-<% end %>
+    <%= form.submit 'Preview Changes', name: 'save', class: 'btn btn-primary btn-block' %>
+    <%= form.submit 'Apply Changes', name: 'save', class: 'btn btn-danger btn-block'%>
+
+    <%= button_tag(name: 'reset', class: 'btn btn-default btn-block', "data-loading-text":"Loading...") do %>
+      <span class="glyphicon glyphicon-refresh" aria-hidden="true"></span> Reset to Defaults
+    <% end %>
+</div><% end %>

--- a/app/views/themes/_form.html.erb
+++ b/app/views/themes/_form.html.erb
@@ -52,17 +52,17 @@
     <div class="row">
       <div class="col-xs-12">
         <%= form.label :primary_text_color %>
-        <%= form.text_field :primary_text_color, class: 'form-control' %>
+        <%= form.color_field :primary_text_color, class: 'form-control' %>
       </div>
 
       <div class="col-xs-12">
         <%= form.label :accent_text_color %>
-        <%= form.text_field :accent_text_color, class: 'form-control' %>
+        <%= form.color_field :accent_text_color, class: 'form-control' %>
       </div>
 
       <div class="col-xs-12">
         <%= form.label :background_color %>
-        <%= form.text_field :background_color, class: 'form-control' %>
+        <%= form.color_field :background_color, class: 'form-control' %>
       </div>
     </div>
   </div>
@@ -70,11 +70,13 @@
   <hr/>
   <div class="actions">
     <%= form.submit 'Preview Changes', name: 'save', class: 'btn btn-primary btn-block' %>
-    <%= button_tag(name: 'apply', class: 'btn btn-danger btn-block') do %>
+
+    <%= button_tag(name: 'apply', class: 'btn btn-success btn-block', value: 'true') do %>
       <span class="glyphicon glyphicon-tint" aria-hidden="true"></span> Apply Changes
     <% end %>
-   
-    <%= button_tag(name: 'reset', class: 'btn btn-default btn-block') do %>
+
+    <%= button_tag(name: 'reset', class: 'btn btn-default btn-block', value: 'true') do %>
       <span class="glyphicon glyphicon-refresh" aria-hidden="true"></span> Reset to Defaults
     <% end %>
-</div><% end %>
+  </div>
+<% end %>


### PR DESCRIPTION
* Adds an "Apply" button to the theme form
* Copies theme settings from the current theme to the corresponding 
     ContentBlock records that Hyrax uses to persist styling information

TODO:
* Review the mappings from theme to appearance
* Update Hyrax styling to apply additional colors to additional elements as desired
* Migrate Theme persistence to ContentBlock - i.e. get rid of the Theme model 
     and use a ContentBlock to store JSON instead