### PR TITLE
Add persistent preview values for themes

### DIFF
--- a/app/controllers/themes_controller.rb
+++ b/app/controllers/themes_controller.rb
@@ -43,6 +43,7 @@ class ThemesController < ApplicationController
     if params[:reset] == "true"
       params[:theme] = Theme::DEFAULTS
       @theme.logo.purge
+      @theme.reset_preview_to_defaults
     end
 
     if @theme.update(theme_params)
@@ -83,6 +84,7 @@ class ThemesController < ApplicationController
 
   def apply_theme_to_site
     theme = Theme.current_theme
+    theme.apply_preview
     appearance_to_theme_mapping = {
       header_background_color:          theme.primary_color,
       header_text_color:                theme.primary_text_color,

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -6,12 +6,18 @@ class Theme < ApplicationRecord
     accent_color: '#D35F00',
     primary_text_color: '#1A1A1A',
     accent_text_color: '#FFFFFF',
-    background_color: '#FFFFFF'
+    background_color: '#FFFFFF',
+    preview_site_title: 'Tenejo',
+    preview_primary_color: '#000000',
+    preview_accent_color: '#D35F00',
+    preview_primary_text_color: '#1A1A1A',
+    preview_accent_text_color: '#FFFFFF',
+    preview_background_color: '#FFFFFF'
     # logo: 'default_logo.png' # see ensure_logo below for logo attachment default
-  )
+  ).freeze
 
   has_one_attached :logo
-  after_initialize :merge_defaults, :ensure_logo
+  after_initialize :merge_defaults, :ensure_logo, :reset_preview_to_defaults
 
   def self.current_theme
     @current_theme ||= Theme.find_or_create_by(id: 1) do |theme|
@@ -23,8 +29,29 @@ class Theme < ApplicationRecord
 
   def reset_to_defaults
     self.attributes = attributes.merge(DEFAULTS)
+    reset_preview_to_defaults
     logo.purge
     ensure_logo
+    save if persisted?
+  end
+
+  def reset_preview_to_defaults
+    self.preview_site_title = DEFAULTS[:site_title]
+    self.preview_primary_color = DEFAULTS[:primary_color]
+    self.preview_accent_color = DEFAULTS[:accent_color]
+    self.preview_primary_text_color = DEFAULTS[:primary_text_color]
+    self.preview_accent_text_color = DEFAULTS[:accent_text_color]
+    self.preview_background_color = DEFAULTS[:background_color]
+    save if persisted?
+  end
+
+  def apply_preview
+    self.site_title = preview_site_title
+    self.primary_color = preview_primary_color
+    self.accent_color = preview_accent_color
+    self.primary_text_color = preview_primary_text_color
+    self.accent_text_color = preview_accent_text_color
+    self.background_color = preview_background_color
     save if persisted?
   end
 

--- a/app/views/shared/_appearance_styles.html.erb
+++ b/app/views/shared/_appearance_styles.html.erb
@@ -11,43 +11,43 @@
       <% theme = Theme.current_theme %>
       <style>
         #homepage-preview {
-          color: <%= theme&.primary_text_color %>;
+          color: <%= theme&.preview_primary_text_color %>;
         }
 
         .preview-header {
-          background-color: <%= theme&.primary_color %>;
-          color: <%= theme&.accent_text_color %>;
+          background-color: <%= theme&.preview_primary_color %>;
+          color: <%= theme&.preview_accent_text_color %>;
           border-radius: 0.5em 0.5em 0 0;
         }
 
         .preview-body {
-          background-color: <%= theme&.background_color %>
+          background-color: <%= theme&.preview_background_color %>
           ;
         }
         .preview-body h1 {
           font-size: 1.5em;
           margin-top: 0;
-          color: <%= theme&.accent_color %>;
+          color: <%= theme&.preview_accent_color %>;
         }
         .preview-body a {
-          color: <%= theme&.accent_color %>;
+          color: <%= theme&.preview_accent_color %>;
         }
 
         .preview-footer {
-          background-color: <%= theme&.primary_color %>;
-          color: <%= theme&.accent_text_color %>;
+          background-color: <%= theme&.preview_primary_color %>;
+          color: <%= theme&.preview_accent_text_color %>;
           border-radius: 0 0 0.5em 0.5em;
         }
 
 
         .preview-navbar-header {
           width: 100%;
-          background-color: <%= theme&.accent_color %>
+          background-color: <%= theme&.preview_accent_color %>
         }
         .preview-navbar-header .btn-primary {
-          background-color: <%= theme&.primary_color %>
+          background-color: <%= theme&.preview_primary_color %>
           ;
-          border-color: <%= theme&.primary_color %>
+          border-color: <%= theme&.preview_primary_color %>
           ;
         }
 
@@ -79,7 +79,7 @@
             line-height: 1 !important;
         }
         .preview-facets .panel-heading.collapse-toggle .panel-title:after{
-            color: <%= theme&.accent_color %>;
+            color: <%= theme&.preview_accent_color %>;
         }
 
         /* / Homepage Styles / */

--- a/app/views/themes/_form.html.erb
+++ b/app/views/themes/_form.html.erb
@@ -17,7 +17,8 @@
     <div class="row">
       <div class="col-xs-12">
         <%= form.label :site_title %>
-        <%= form.text_field :site_title, class: 'form-control' %>
+        <%= form.text_field :preview_site_title, class: 'form-control' %>
+        <%= form.hidden_field :site_title %>
       </div>
     </div>
   </div>
@@ -39,11 +40,13 @@
     <div class="row">
       <div class="col-xs-12">
         <%= form.label :primary_color %>
-        <%= form.color_field :primary_color, class: 'form-control' %>
+        <%= form.color_field :preview_primary_color, class: 'form-control' %>
+        <%= form.hidden_field :primary_color %>
       </div>
       <div class="col-xs-12">
         <%= form.label :accent_color %>
-        <%= form.color_field :accent_color, class: 'form-control' %>
+        <%= form.color_field :preview_accent_color, class: 'form-control' %>
+        <%= form.hidden_field :accent_color %>
       </div>
     </div>
   </div>
@@ -52,17 +55,20 @@
     <div class="row">
       <div class="col-xs-12">
         <%= form.label :primary_text_color %>
-        <%= form.color_field :primary_text_color, class: 'form-control' %>
+        <%= form.color_field :preview_primary_text_color, class: 'form-control' %>
+        <%= form.hidden_field :primary_text_color %>
       </div>
 
       <div class="col-xs-12">
         <%= form.label :accent_text_color %>
-        <%= form.color_field :accent_text_color, class: 'form-control' %>
+        <%= form.color_field :preview_accent_text_color, class: 'form-control' %>
+        <%= form.hidden_field :accent_text_color %>
       </div>
 
       <div class="col-xs-12">
         <%= form.label :background_color %>
-        <%= form.color_field :background_color, class: 'form-control' %>
+        <%= form.color_field :preview_background_color, class: 'form-control' %>
+        <%= form.hidden_field :background_color %>
       </div>
     </div>
   </div>

--- a/db/migrate/20211213194215_add_previews_to_themes.rb
+++ b/db/migrate/20211213194215_add_previews_to_themes.rb
@@ -1,0 +1,10 @@
+class AddPreviewsToThemes < ActiveRecord::Migration[5.2]
+  def change
+    add_column :themes, :preview_site_title, :string
+    add_column :themes, :preview_primary_color, :string
+    add_column :themes, :preview_accent_color, :string
+    add_column :themes, :preview_primary_text_color, :string
+    add_column :themes, :preview_accent_text_color, :string
+    add_column :themes, :preview_background_color, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_05_193250) do
+ActiveRecord::Schema.define(version: 2021_12_13_194215) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -523,6 +523,12 @@ ActiveRecord::Schema.define(version: 2021_12_05_193250) do
     t.string "background_color"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "preview_site_title"
+    t.string "preview_primary_color"
+    t.string "preview_accent_color"
+    t.string "preview_primary_text_color"
+    t.string "preview_accent_text_color"
+    t.string "preview_background_color"
   end
 
   create_table "tinymce_assets", force: :cascade do |t|

--- a/spec/models/theme_spec.rb
+++ b/spec/models/theme_spec.rb
@@ -22,15 +22,40 @@ RSpec.describe Theme, type: :model do
     expect(described_class.current_theme.id).to eq 1
   end
 
-  it 'can .reset_to_defaults', :aggregate_failures do
+  it 'can .reset_preview_to_defaults', :aggregate_failures do
     theme = described_class.new(site_title: 'Not Your Average Default', primary_color: '#ABCDEF')
     expect(theme.site_title).to eq 'Not Your Average Default'
     expect(theme.primary_color).to eq '#ABCDEF'
 
     theme.reset_to_defaults
 
-    expect(theme.site_title).to eq Theme::DEFAULTS[:site_title]
-    expect(theme.primary_color).to eq Theme::DEFAULTS[:primary_color]
+    expect(theme.preview_site_title).to eq Theme::DEFAULTS[:site_title]
+    expect(theme.preview_primary_color).to eq Theme::DEFAULTS[:primary_color]
+  end
+
+  context '.apply_preview', :aggregate_failures do
+    it 'updates main values from preview' do
+      theme = described_class.new
+      expect(theme.site_title).to eq 'Tenejo'
+      expect(theme.primary_color).to eq '#000000'
+
+      theme.preview_site_title = "New and Improved"
+      theme.preview_primary_color = "DarkOliveGreen"
+      theme.apply_preview
+
+      expect(theme.site_title).to eq "New and Improved"
+      expect(theme.primary_color).to eq "DarkOliveGreen"
+    end
+
+    it 'works on a persisted theme', :aggregate_failures do
+      theme = described_class.current_theme
+
+      theme.preview_site_title = "New and Improved"
+      expect { theme.apply_preview }.not_to raise_error
+
+      updated_theme = described_class.find(theme.id)
+      expect(updated_theme.site_title).to eq "New and Improved"
+    end
   end
 
   it 'has a default logo' do

--- a/spec/requests/themes_spec.rb
+++ b/spec/requests/themes_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "/themes", type: :request do
     it "applies defaults to the whole site", :aggregate_failures do
       ContentBlock.find_or_create_by(name: "header_background_color").update!(value: '#010101')
       new_color = '#0FF0FF88'
-      patch theme_url, params: { theme: { primary_color: new_color } }
+      patch theme_url, params: { theme: { preview_primary_color: new_color } }
       patch theme_url, params: { apply: "true", theme: { site_title: 'Tenejo' } }
       background_color = ContentBlock.find_by(name: "header_background_color").value
       expect(background_color).to eq new_color


### PR DESCRIPTION
For each styling option in the Theme preview, add a a new value
prefixed with `preview_`.  These values are used to render the styling
for the preview and the non-prefixed values are used for rendering
the main site.

E.G.
`preview_primary_color` displays in the dashboard preview
`primary_color` displays on the main site

"Apply Changes" copies the settings from preview_ to the main values
"Reset to Defaults" resets preview values to default, you still need
to apply the changes if you want to reset the whole site to default
styling.