### PR TITLE
Remove deduplication_key from the import process

### DIFF
--- a/app/lib/tenejo/pf_object.rb
+++ b/app/lib/tenejo/pf_object.rb
@@ -43,8 +43,8 @@ module Tenejo
   end
 
   class PFCollection < PreFlightObj
-    ALL_FIELDS = (Collection.terms + [:deduplication_key, :visibility, :parent]).uniq.freeze
-    REQUIRED_FIELDS = (Collection.required_terms + [:identifier, :deduplication_key, :visibility]).uniq.freeze
+    ALL_FIELDS = (Collection.terms + [:visibility, :parent]).uniq.freeze
+    REQUIRED_FIELDS = (Collection.required_terms + [:identifier, :visibility]).uniq.freeze
     attr_accessor(*ALL_FIELDS)
     validates_presence_of(*REQUIRED_FIELDS)
 
@@ -88,13 +88,8 @@ module Tenejo
   end
 
   class PFWork < PreFlightObj
-    # ALL_FIELDS = [:title, :identifier, :deduplication_key, :creator, :keyword, :files,
-    #               :visibility, :license, :parent, :rights_statement, :resource_type,
-    #               :abstract_or_summary, :date_created, :subject, :language, :publisher, :related_url,
-    #               :location, :source, :bibliographic_citation].freeze
-    ALL_FIELDS = (Work.terms + [:deduplication_key, :visibility, :parent, :files]).uniq.freeze
-    # REQUIRED_FIELDS = [:title, :identifier, :deduplication_key, :creator, :keyword, :visibility, :parent].freeze
-    REQUIRED_FIELDS = (Work.required_terms + [:identifier, :deduplication_key, :visibility]).uniq.freeze
+    ALL_FIELDS = (Work.terms + [:visibility, :parent, :files]).uniq.freeze
+    REQUIRED_FIELDS = (Work.required_terms + [:identifier, :visibility]).uniq.freeze
 
     attr_accessor(*ALL_FIELDS)
     validates_presence_of(*REQUIRED_FIELDS)

--- a/spec/fixtures/csv/bad_ot.csv
+++ b/spec/fixtures/csv/bad_ot.csv
@@ -1,3 +1,3 @@
 
-Identifier,deduplication_key,object type,parent,title,creator,keyword,Rights Statement,Visibility,files,Resource Type,abstract,Contributor,License,Publisher,Date Created,Subject,Language,Related Url,bibliographic_citation,Source
-TESTINGCOLLECTION,TESTINGCOLLECTION,potato,,The testing collection,mml,test,,open,,Collection,A collection of test things,mml,,,,,,,,
+Identifier,object type,parent,title,creator,keyword,Rights Statement,Visibility,files,Resource Type,abstract,Contributor,License,Publisher,Date Created,Subject,Language,Related Url,bibliographic_citation,Source
+TESTINGCOLLECTION,potato,,The testing collection,mml,test,,open,,Collection,A collection of test things,mml,,,,,,,,

--- a/spec/fixtures/csv/dupe_col.csv
+++ b/spec/fixtures/csv/dupe_col.csv
@@ -1,5 +1,5 @@
 
-Identifier,identifier,deduplication_key,deduplication key,object type,parent,title,creator,keyword,Rights Statement,Visibility,files,Resource Type,abstract or summary,Contributor,License,Publisher,Date Created,Subject,Language,location,Related Url,bibliographic_citation,Source
+Identifier,identifier,object type,parent,title,title,creator,keyword,Rights Statement,Visibility,files,Resource Type,abstract or summary,Contributor,License,Publisher,Date Created,Subject,Language,location,Related Url,bibliographic_citation,Source
 TESTINGCOLLECTION,TESTINGCOLLECTION,C,,The testing collection,mml,test,,open,,Collection,A collection of test things,mml,,,,,,,,,
 NONACOLLECTION,NONACOLLECTION,CoLleCtiOn,NONEXISTENT,a child of a nonexistent collection, mml,test,,open,,Collection,A collection of test things,mml,,,,,,,,,
 MPC002,MPC002,W,TESTINGCOLLECTION,"TEST Postcards - Minneapolis UNPACKED FILES - Canoeing on Lake Harriet, Minneapolis",Minneapolis Selling Company,postcard|~|Minneapolis|~|Lake Harriet,http://rightsstatements.org/vocab/NoC-OKLR/1.0/,open,,Image,"Postcard depicting Lake Harriet in Minnneapolis, MN",,http://creativecommons.org/publicdomain/mark/1.0/,,1900-1945,Postcards,English,,,,

--- a/spec/fixtures/csv/empty.csv
+++ b/spec/fixtures/csv/empty.csv
@@ -1,7 +1,7 @@
 
-Identifier,deduplication_key,object type,parent,title,creator,keyword,Rights Statement,Visibility,files,Resource Type,abstract,Contributor,License,Publisher,Date Created,Subject,Language,Related Url,bibliographic_citation,Source
-,,,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,,,
+Identifier,object type,parent,title,creator,keyword,Rights Statement,Visibility,files,Resource Type,abstract,Contributor,License,Publisher,Date Created,Subject,Language,Related Url,bibliographic_citation,Source
+,,,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,,,
 
 
-,,,,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,,,

--- a/spec/fixtures/csv/missing_cols.csv
+++ b/spec/fixtures/csv/missing_cols.csv
@@ -1,2 +1,2 @@
-Identifier,deduplication_key,object type,parent,title,creator,keyword,Rights Statement,Visibility,files,Resource Type,abstract,Contributor,License,Publisher,Date Created,Subject,Language,Related Url,bibliographic_citation,Source
-'TESTINGCOLLECTION','TESTINGCOLLECTION',C,,The ,testing collection',mml,'test',,'open',,Collection,A collection of test things,mml,,,,,,,,
+Identifier,object type,parent,title,creator,keyword,Rights Statement,Visibility,files,Resource Type,abstract,Contributor,License,Publisher,Date Created,Subject,Language,Related Url,bibliographic_citation,Source
+'TESTINGCOLLECTION',C,,The ,testing collection',mml,'test',,'open',,Collection,A collection of test things,mml,,,,,,,,

--- a/spec/lib/tenejo/preflight_spec.rb
+++ b/spec/lib/tenejo/preflight_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Tenejo::Preflight do
     let(:dupes) { described_class.read_csv("spec/fixtures/csv/dupe_col.csv", "tmp/uploads") }
 
     it "records fatal error for duplicate column " do
-      expect(dupes[:fatal_errors]).to include "Duplicate column names detected [:identifier, :identifier, :deduplication_key, :deduplication_key], cannot process"
+      expect(dupes[:fatal_errors]).to include "Duplicate column names detected [:identifier, :identifier, :title, :title], cannot process"
     end
   end
   context "a file that isn't a csv " do
@@ -145,9 +145,8 @@ RSpec.describe Tenejo::Preflight do
     let(:rec) { described_class.new({}, 1) }
     it "is not valid when blank" do
       expect(rec.valid?).not_to eq true
-      expect(rec.errors.messages).to eq deduplication_key: ["can't be blank"],
-        identifier: ["can't be blank"], title: ["can't be blank"], creator: ["can't be blank"],
-        visibility: ["can't be blank"]
+      expect(rec.errors.messages).to eq identifier: ["can't be blank"],
+        title: ["can't be blank"], creator: ["can't be blank"], visibility: ["can't be blank"]
     end
     it "transforms visibility" do
       rec = described_class.new({ visibility: 'Public' }, 1)
@@ -226,7 +225,7 @@ RSpec.describe Tenejo::Preflight do
     let(:rec) { described_class.new({}, 1) }
     it "is not valid when blank" do
       expect(rec.valid?).not_to eq true
-      expect(rec.errors.messages).to eq deduplication_key: ["can't be blank"], identifier: ["can't be blank"],
+      expect(rec.errors.messages).to eq identifier: ["can't be blank"],
         title: ["can't be blank"], visibility: ["can't be blank"]
     end
   end


### PR DESCRIPTION
Going forward we're going to rely on the user supplied
identifier to match import records against pre-existing content
in the repository.