### PR TITLE
Update solr version to address Log4j vulnerabilities

### DIFF
--- a/.solr_wrapper.yml
+++ b/.solr_wrapper.yml
@@ -1,5 +1,5 @@
 # Place any default configuration for solr_wrapper here
-version: 8.10.1
+version: 8.11.1
 # port: 8983
 instance_dir: tmp/solr-development
 collection:

--- a/config/solr_wrapper_test.yml
+++ b/config/solr_wrapper_test.yml
@@ -1,5 +1,5 @@
 #config/solr_wrapper_test.yml
-version: 8.10.1
+version: 8.11.1
 port: 8985
 instance_dir: tmp/solr-test
 collection:


### PR DESCRIPTION
Includes SOLR-15843: Update Log4J to 2.16

See https://solr.apache.org/docs/8_11_1/changes/Changes.html and https://logging.apache.org/log4j/2.x/security.html