### PR TITLE
Dashboard sidebar content defaults changed from "My" to "All"

### DIFF
--- a/app/controllers/concerns/hyrax/breadcrumbs_for_collections.rb
+++ b/app/controllers/concerns/hyrax/breadcrumbs_for_collections.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+module Hyrax
+  module BreadcrumbsForCollections
+    extend ActiveSupport::Concern
+    include Hyrax::Breadcrumbs
+
+    included do
+      before_action :build_breadcrumbs, only: [:edit, :show]
+    end
+
+    def add_breadcrumb_for_controller
+      add_breadcrumb I18n.t('hyrax.dashboard.my.collections'), hyrax.dashboard_collections_path
+    end
+
+    def add_breadcrumb_for_action
+      case action_name
+      when 'edit'
+        add_breadcrumb I18n.t("hyrax.collection.edit_view"), collection_path(params["id"]), mark_active_action
+      when 'show'
+        add_breadcrumb presenter.to_s, polymorphic_path(presenter), mark_active_action
+      end
+    end
+
+    def mark_active_action
+      { "aria-current" => "page" }
+    end
+  end
+end

--- a/app/controllers/concerns/hyrax/breadcrumbs_for_works.rb
+++ b/app/controllers/concerns/hyrax/breadcrumbs_for_works.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+module Hyrax
+  module BreadcrumbsForWorks
+    extend ActiveSupport::Concern
+    include Hyrax::Breadcrumbs
+
+    class_methods do
+      # We don't want the breadcrumb action to occur until after the concern has
+      # been loaded and authorized
+      def curation_concern_type=(curation_concern_type)
+        super
+        before_action :build_breadcrumbs, only: [:edit, :show, :new]
+      end
+    end
+
+    private
+
+    def build_breadcrumbs
+      return super if action_name == 'show'
+      # These breadcrumbs are for the edit/create actions
+      add_breadcrumb t(:'hyrax.controls.home'), root_path
+      add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
+      add_breadcrumb_for_controller
+      add_breadcrumb_for_action
+    end
+
+    def add_breadcrumb_for_controller
+      add_breadcrumb I18n.t(:'hyrax.dashboard.my.works'), hyrax.dashboard_works_path
+    end
+
+    def add_breadcrumb_for_action
+      case action_name
+      when 'edit'
+        add_breadcrumb curation_concern.to_s, main_app.polymorphic_path(curation_concern)
+        add_breadcrumb t(:'hyrax.works.edit.breadcrumb'), request.path
+      when 'new'
+        add_breadcrumb t(:'hyrax.works.create.breadcrumb'), request.path
+      when 'show'
+        add_breadcrumb presenter.to_s, main_app.polymorphic_path(presenter)
+      end
+    end
+  end
+end

--- a/app/controllers/hyrax/my/collections_controller.rb
+++ b/app/controllers/hyrax/my/collections_controller.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+module Hyrax
+  module My
+    class CollectionsController < MyController
+      configure_blacklight do |config|
+        config.search_builder_class = Hyrax::My::CollectionsSearchBuilder
+      end
+      # Define collection specific filter facets.
+      def self.configure_facets
+        configure_blacklight do |config|
+          # Name of pivot facet must match field name that uses helper_method
+          config.add_facet_field Hyrax.config.collection_type_index_field,
+                                 helper_method: :collection_type_label, limit: 5,
+                                 pivot: ['has_model_ssim', Hyrax.config.collection_type_index_field],
+                                 label: I18n.t('hyrax.dashboard.my.heading.collection_type')
+          # This causes AdminSets to also be shown with the Collection Type label
+          config.add_facet_field 'has_model_ssim',
+                                 label: I18n.t('hyrax.dashboard.my.heading.collection_type'),
+                                 limit: 5, show: false
+        end
+      end
+      configure_facets
+
+      def index
+        add_breadcrumb t(:'hyrax.controls.home'), root_path
+        add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
+        add_breadcrumb t(:'hyrax.admin.sidebar.collections'), hyrax.dashboard_collections_path
+        collection_type_list_presenter
+        managed_collections_count
+        super
+      end
+
+      private
+
+      def search_action_url(*args)
+        hyrax.my_collections_url(*args)
+      end
+
+      # The url of the "more" link for additional facet values
+      def search_facet_path(args = {})
+        hyrax.my_dashboard_collections_facet_path(args[:id])
+      end
+
+      def collection_type_list_presenter
+        @collection_type_list_presenter ||= Hyrax::SelectCollectionTypeListPresenter.new(current_user)
+      end
+
+      def managed_collections_count
+        @managed_collection_count = Hyrax::Collections::ManagedCollectionsService.managed_collections_count(scope: self)
+      end
+    end
+  end
+end

--- a/app/controllers/hyrax/my/works_controller.rb
+++ b/app/controllers/hyrax/my/works_controller.rb
@@ -21,7 +21,7 @@ module Hyrax
 
         add_breadcrumb t(:'hyrax.controls.home'), root_path
         add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
-        add_breadcrumb t(:'hyrax.admin.sidebar.works'), hyrax.my_works_path 
+        add_breadcrumb t(:'hyrax.admin.sidebar.works'), hyrax.my_works_path
         managed_works_count
         @create_work_presenter = create_work_presenter_class.new(current_user)
         super

--- a/app/controllers/hyrax/my/works_controller.rb
+++ b/app/controllers/hyrax/my/works_controller.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+module Hyrax
+  module My
+    class WorksController < MyController
+      # Define collection specific filter facets.
+      def self.configure_facets
+        configure_blacklight do |config|
+          config.search_builder_class = Hyrax::My::WorksSearchBuilder
+          config.add_facet_field "admin_set_sim", limit: 5
+          config.add_facet_field "member_of_collections_ssim", limit: 5
+        end
+      end
+      configure_facets
+
+      class_attribute :create_work_presenter_class
+      self.create_work_presenter_class = Hyrax::SelectTypeListPresenter
+
+      def index
+        # The user's collections for the "add to collection" form
+        @user_collections = collections_service.search_results(:deposit)
+
+        add_breadcrumb t(:'hyrax.controls.home'), root_path
+        add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
+        add_breadcrumb t(:'hyrax.admin.sidebar.works'), hyrax.my_works_path 
+        managed_works_count
+        @create_work_presenter = create_work_presenter_class.new(current_user)
+        super
+      end
+
+      private
+
+      def collections_service
+        Hyrax::CollectionsService.new(self)
+      end
+
+      def search_action_url(*args)
+        hyrax.my_works_url(*args)
+      end
+
+      # The url of the "more" link for additional facet values
+      def search_facet_path(args = {})
+        hyrax.my_dashboard_works_facet_path(args[:id])
+      end
+
+      def managed_works_count
+        @managed_works_count = Hyrax::Works::ManagedWorksService.managed_works_count(scope: self)
+      end
+    end
+  end
+end

--- a/app/views/hyrax/dashboard/sidebar/_repository_content.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_repository_content.html.erb
@@ -1,0 +1,15 @@
+  <li class="h5"><%= t('hyrax.admin.sidebar.repository_objects') %></li>
+
+  <%= menu.nav_link(hyrax.dashboard_collections_path,
+                    onclick: "dontChangeAccordion(event);",
+                    also_active_for: hyrax.my_collections_path) do %>
+    <span class="fa fa-folder-open" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.collections') %></span>
+  <% end %>
+
+  <%= menu.nav_link(hyrax.dashboard_works_path,
+                    onclick: "dontChangeAccordion(event);",
+                    also_active_for: hyrax.my_works_path) do %>
+    <span class="fa fa-file" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.works') %></span>
+  <% end %>
+
+  <%= render 'hyrax/dashboard/sidebar/menu_partials', menu: menu, section: :repository_content %>


### PR DESCRIPTION
Fixes to breadcrumbs and sidebar link for works and collections.

- view collections from the dashboard goes to view 'all collections' by default
- view works from the dashboard goes to view 'all works' by default