### PR TITLE
Show tenejo version info on production environments

### DIFF
--- a/app/helpers/footer_helper.rb
+++ b/app/helpers/footer_helper.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module FooterHelper
+  # returns true if running in a full production environment
+  def production_host?
+    return false if request.host == 'localhost' # dev and test environments
+    return false if request.host.include?('-')  # hostnames like qa-etd, tenejo-dev
+    true # hostnames without a dash
+  end
+end

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -2,7 +2,13 @@
   <div class="container-fluid">
     <div class="navbar-text text-left">
       <span>Powered by Tenejo</span>
-      <% if Rails.env.development? %>
+      <% if production_host? %>
+        <div class="version">
+          <%= BRANCH %>
+        </div>
+      <% end %>
+      <% unless production_host? %>
+        <%# Display detailed git information in dev, test, and non-production environments %>
         <div class="version">
           ENV: <%= Rails.env %>
           <br>SHA: <%= GIT_SHA %>

--- a/config/initializers/git_sha.rb
+++ b/config/initializers/git_sha.rb
@@ -18,9 +18,9 @@ GIT_SHA =
 BRANCH =
   if CAPISTRANO_RELEASE
     CAPISTRANO_RELEASE[1]
-  elsif Rails.env.development? || Rails.env.test?
+  elsif Rails.env.development?
     `git rev-parse --abbrev-ref HEAD`.chomp
-  else
+  else # Rails.env.test?
     "Unknown branch"
   end
 

--- a/spec/helpers/footer_helper_spec.rb
+++ b/spec/helpers/footer_helper_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+describe FooterHelper do
+  describe '#production_host?' do
+    it 'returns true for hosts without a hyphen in their name' do
+      controller.request.host = 'production.example.com'
+      expect(helper.production_host?).to eq true
+    end
+    it 'returns false for localhost' do
+      controller.request.host = 'localhost'
+      expect(helper.production_host?).to eq false
+    end
+    it 'returns false for hosts with a hyphen in their name' do
+      controller.request.host = 'prod-like.example.com'
+      expect(helper.production_host?).to eq false
+    end
+  end
+end

--- a/spec/views/shared/_footer.html.erb_spec.rb
+++ b/spec/views/shared/_footer.html.erb_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe "shared/_footer", type: :view do
+  context "on prod-like servers" do
+    # Assumes that prod-like servers have an environment name separated by a dash in the hostname\
+    # See FooterHelper for details
+    it 'displays detailed git information' do
+      controller.request.host = 'prod-like.example.com'
+      render
+      expect(rendered).to have_selector('.version', text: "SHA")
+    end
+  end
+
+  context "on production servers" do
+    # Assumes that production servers do not have dashed in hostnames
+    it 'displays only version info' do
+      controller.request.host = 'production.example.com'
+      render
+      expect(rendered).to have_selector('.version', text: "Unknown branch")
+      expect(rendered).to have_no_selector('.version', text: "SHA")
+    end
+  end
+
+  context "on local development and test environments" do
+    it 'displays detailed git information' do
+      controller.request.host = 'localhost'
+      render
+      expect(rendered).to have_selector('.version', text: "SHA")
+    end
+  end
+end


### PR DESCRIPTION
When the application is running in a production environment only the
current release version or branch is displayed.

In other environments, more detailed git commit information
and delpoyment dates are displayed.

For lack of a better method to detect produciton environments, the
code assumes that hostnames without hyphens are production:
* tenejo = production (only display version)
* tenejo-dev = non-production (display detailed deploy info)
* localhost = non-production (display detailed commit info)

**PRODUCTION**
![image](https://user-images.githubusercontent.com/3064318/149013910-3ae1ea78-1c1b-48a3-ae14-d72f5b5122f9.png)

**OTHER ENVIRONMENTS**
![image](https://user-images.githubusercontent.com/3064318/149013669-b34fb7a2-d096-40ed-a99c-df47ab8a1bde.png)
