### PR TITLE
Changes to preflight

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,9 +17,11 @@ jobs:
           DATABASE_USERNAME: postgres
           POSTGRES_HOST: 127.0.0.1
           POSTGRES_USER: postgres
-          WORKING_PATH: /tmp
-          UPLOAD_PATH: /tmp
-          CACHE_PATH: /tmp/cache
+          WORKING_PATH: tmp/test/uploads
+          DERIVATIVES_PATH: tmp/test/derivatives
+          IMPORT_PATH: tmp/test/import
+          UPLOAD_PATH: tmp/test/uploads
+          CACHE_PATH: tmp/cache
           FEDORA_TEST_URL: http://127.0.0.1:8080/fcrepo/rest
           SOLR_TEST_URL: http://127.0.0.1:8985/solr/hydra-test
           COVERAGE: 1

--- a/.env.test
+++ b/.env.test
@@ -5,9 +5,9 @@ GEONAMES_USERNAME=tenejodemo
 RAILS_SERVE_STATIC_FILES=true
 SIDEKIQ_WORKERS=5
 
-export UPLOAD_PATH=tmp/test/uploads
-export CACHE_PATH=tmp/test/uploads/cache
-export WORKING_PATH=tmp/test/uploads
+UPLOAD_PATH=tmp/test/uploads
+CACHE_PATH=tmp/test/uploads/cache
+WORKING_PATH=tmp/test/uploads
 DERIVATIVES_PATH=tmp/test/derivatives
 IMPORT_PATH=tmp/test/import
 

--- a/app/controllers/preflights_controller.rb
+++ b/app/controllers/preflights_controller.rb
@@ -16,7 +16,7 @@ class PreflightsController < JobsController
 
   def create
     @job = Preflight.new(job_params.merge({ user: current_user }))
-    run_preflight(@job) if @job.validate
+    @graph = run_preflight(@job) if @job.validate
 
     respond_to do |format|
       if @job.save
@@ -44,5 +44,6 @@ class PreflightsController < JobsController
     job.files = preflight_graph[:file].count
     job.completed_at = Time.current
     job.status = :completed
+    preflight_graph
   end
 end

--- a/spec/fixtures/csv/noid.csv
+++ b/spec/fixtures/csv/noid.csv
@@ -1,9 +1,9 @@
-Identifier,deduplication_key,object type,parent,title,creator,keyword,Rights Statement,Visibility,files,Resource Type,Description,Contributor,License,Publisher,Date Created,Subject,Language,Related Url,bibliographic_citation,Source
+Id,deduplication_key,object type,parent,title,creator,keyword,Rights Statement,Visibility,files,Resource Type,Description,Contributor,License,Publisher,Date Created,Subject,Language,Related Url,bibliographic_citation,Source
 TESTINGCOLLECTION,TESTINGCOLLECTION,C,,The testing collection,mml,test,,open,,Collection,A collection of test things,mml,,,,,,,,
 NONACOLLECTION,NONACOLLECTION,CoLleCtiOn,NONEXISTENT,a child of a nonexistent collection, mml,test,,open,,Collection,A collection of test things,mml,,,,,,,,
 MPC002,MPC002,W,TESTINGCOLLECTION,"TEST Postcards - Minneapolis UNPACKED FILES - Canoeing on Lake Harriet, Minneapolis",Minneapolis Selling Company,postcard|~|Minneapolis|~|Lake Harriet,http://rightsstatements.org/vocab/NoC-OKLR/1.0/,open,,Image,"Postcard depicting Lake Harriet in Minnneapolis, MN",,http://creativecommons.org/publicdomain/mark/1.0/,,1900-1945,Postcards,English,,,
 ,,fIle,MPC002,,,,,,MN-02 2.png|~|MN-02 3.png,Image,,,,,,,,,,
-,,fIle,WHUT?,,,,,,MN-02 2.png,Image,,,,,,,,,,
+,,fIle,WHUT?,,,,,,MN-02 2.whut,Image,,,,,,,,,,
 MPC003,MPC003,W,TESTINGCOLLECTION,"TEST Postcards - Minneapolis UNPACKED FILES - Lake Harriet, Minneapolis, Minn",Bloom Bros Co.,postcard|~|Minneapolis|~|Lake Harriet,https://rightsstatements.org/vocab/NoC-OKLR/1.0/,open,,Image,Postcard depicting Lake Harriet,,http://creativecommons.org/publicdomain/mark/1.0/,,1900-1945,Postcards,English,,,
 ,,F,MPC003,,,,,,MN-02 4.png,Image,,,,,,,,,,
 MPC008,MPC008,W,MPC003,"TEST Postcards - Minneapolis UNPACKED FILES - Lake Harriet, Minneapolis, Minn",Bloom Bros Co.,postcard|~|Minneapolis|~|Lake Harriet,http://rightsstatements.org/vocab/NoC-OKLR/1.0/,open,,Image,Postcard depicting Lake Harriet,,http://creativecommons.org/publicdomain/mark/1.0/,,1900-1945,Postcards,English,,,

--- a/spec/lib/tenejo/csv_importer_spec.rb
+++ b/spec/lib/tenejo/csv_importer_spec.rb
@@ -1,8 +1,17 @@
 # frozen_string_literal: true
+require 'csv'
 require 'rails_helper'
 require 'active_fedora/cleaner'
 
 RSpec.describe Tenejo::CsvImporter do
+  before :all do
+    # this nonsense is to create relevant files so that the preflighter will not reject the records
+    r = CSV.read('spec/fixtures/csv/structure_test.csv')
+    FileUtils.mkdir_p('tmp/test/uploads')
+    r.map { |z| z[8] }.reject(&:nil?).map { |t| t.split('|~|') }.flatten.reject { |k| k == 'Files' }.each do |f|
+      FileUtils.touch("tmp/test/uploads/#{f}")
+    end
+  end
   let(:job_owner) { FactoryBot.create(:user) }
   let(:csv) { fixture_file_upload("./spec/fixtures/csv/structure_test.csv") }
   let(:preflight) { Preflight.create!(user: job_owner, manifest: csv) }

--- a/spec/requests/preflight_request_spec.rb
+++ b/spec/requests/preflight_request_spec.rb
@@ -39,6 +39,12 @@ RSpec.describe "/preflights", type: :request do
   end
 
   describe "POST /create" do
+    before :all do
+      FileUtils.mkdir_p('tmp/test/uploads')
+      FileUtils.touch("tmp/test/uploads/MN-02 2.png")
+      FileUtils.touch("tmp/test/uploads/MN-02 3.png")
+      FileUtils.touch("tmp/test/uploads/MN-02 4.png")
+    end
     let(:valid_attributes) { { user: admin, manifest: tempfile } }
     let(:tempfile) { fixture_file_upload('csv/fancy.csv') }
 
@@ -56,7 +62,8 @@ RSpec.describe "/preflights", type: :request do
 
       it "sets the collections, works, and jobs count", :aggregate_failures do
         post preflights_path, params: { preflight: valid_attributes }
-        created_job = Job.last
+        created_job = assigns(:job)
+        expect(assigns(:graph)).not_to be_nil
         expect(created_job.status).to eq 'completed'
         expect(created_job.completed_at).to be_within(1.second).of Time.current
         expect(created_job.collections).to eq 2


### PR DESCRIPTION
Preflight now removes invalid objects from consideration before trying
to connect the graph relationships. Invalid objects are stored in
graph[:invalid], and removed from further consideration.
