### PR TITLE
Add UI for viewing import status

### DIFF
--- a/app/assets/stylesheets/jobs.scss
+++ b/app/assets/stylesheets/jobs.scss
@@ -5,3 +5,23 @@
 #jobs-index {
   td, th { padding: 5px; }
 }
+
+table.job {
+  width: 100%;
+  thead { font-weight: bold; }
+  .identifier { width: 25%; }
+  .lineno { width: 5%; }
+  .type { width: 5%;}
+  .visibility { width: 8%; }
+  .collection_count { width: 3%; }
+  .work_count { width: 3%; }
+  .file_count { width: 3%; }
+  .index { width: 5%; text-align: center; }
+  .title { width:26%; }
+  .filename { width:23%; }
+}
+
+.file-name {
+  padding-left: 1.5rem;
+  font-style: italic;
+}

--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -10,6 +10,11 @@ class ImportsController < JobsController
     redirect_to new_preflight_path
   end
 
+  def show
+    import_graph = Tenejo::Preflight.process_csv(@job.manifest.download)
+    @root = import_graph.root
+  end
+
   def create
     @job = Import.new(job_params)
     @job.user = current_user

--- a/app/views/imports/_child.html.erb
+++ b/app/views/imports/_child.html.erb
@@ -1,0 +1,38 @@
+<table class="job">
+  <tbody>
+    <tr>
+      <td class="identifier" style="padding-left: <%= depth * 2 %>rem;">
+        <% if node.children.any? || node.try(:files).try(:any?) %>
+          <button class="btn btn-info btn-xs import_expand" type="button" data-toggle="collapse" data-target=".child-of-<%= node.lineno %>" aria-expanded="false" aria-controls=".children-#{node.lineno}">
+            +
+          </button>
+        <% end %>
+        <%= node.identifier.first %>
+      </td>
+      <td class="lineno"><%= node.lineno %></td>
+      <td class="type"><%= node.class.to_s.delete_prefix("Tenejo::PF").truncate(4, omission: "") %></td>
+      <td class="visibility"><%= node.visibility %></td>
+      <td class="collection_count"> -</td>
+      <td class="work_count"> -</td>
+      <td class="file_count"> -</td>
+      <td class="index"></td>
+      <td class="title"><%= node.title.first %></td>
+      <td class="filename"></td>
+    </tr>
+  </tbody>
+</table>
+<div class="job collapse in child-of-<%= node.lineno %>">
+  <% node.children.each do |child| %>
+    <%= render "child", node: child, parent: node.lineno, depth: depth + 1 %>
+  <% end %>
+  <% if node.try(:files).try(:any?) %>
+    <% node.files.each_with_index do |file, index| %>
+      <%= render "file", node: file, parent: node.lineno, depth: depth + 1, order: index + 1 %>
+    <% end %>
+  <% end %>
+</div>
+
+
+
+
+

--- a/app/views/imports/_file.html.erb
+++ b/app/views/imports/_file.html.erb
@@ -1,0 +1,19 @@
+<table class="job">
+  <tbody>
+    <tr class="file">
+      <td class="identifier" style="padding-left: <%= depth * 2 %>rem;">
+        <i class="fa fa-file-o" aria-hidden="true"></i>
+        <%= node.try(:identifier).try(:first) || "auto" %>
+      </td>
+      <td class="lineno"><%= node.lineno %></td>
+      <td class="type"><%= node.class.to_s.delete_prefix("Tenejo::PF").truncate(4, omission: "") %></td>
+      <td class="visibility"><%= node.visibility %></td>
+      <td class="collection_count"> -</td>
+      <td class="work_count"> -</td>
+      <td class="file_count"> -</td>
+      <td class="index"><%= order %></td>
+      <td class="title"><span class="file-name"> <%= node.files %></span></td>
+      <td class="filename"></td>
+    </tr>
+  </tbody>
+</table>

--- a/app/views/imports/show.html.erb
+++ b/app/views/imports/show.html.erb
@@ -1,0 +1,68 @@
+<h1>Import Job #<%= @job&.id %></h1>
+
+<%# JOB OVERVIEW %>
+<div id="import-user"><p>
+  <strong>User:</strong>
+  <%= @job&.user %>
+</p></div>
+
+<div id="import-manifest"><p>
+  <strong>File:</strong>
+  <% if @job&.parent_job&.manifest&.attached? %>
+    <%= link_to(@job&.parent_job.manifest.filename, rails_blob_path(@job&.parent_job.manifest, disposition: 'attachment')) %>
+  <% else %>
+    --
+  <% end %>
+</p></div>
+
+<div id="import-created_at"><p>
+  <strong>Submitted:</strong>
+  <%= @job&.created_at %>
+</p></div>
+
+<div id="import-status"><p>
+  <strong>Status:</strong>
+  <%= @job&.status || 'Unknown'%>
+</p></div>
+
+<div id="import-completed_at"><p>
+  <strong>Completed at:</strong>
+  <%= @job&.completed_at || '--' %>
+</p></div>
+
+<div id="import-collections"><p>
+  <strong>Collections:</strong>
+  <%= @job&.collections || '--' %>
+</p></div>
+
+<div id="import-works"><p>
+  <strong>Works:</strong>
+  <%= @job&.works || '--' %>
+</p></div>
+
+<div id="import-files"><p>
+  <strong>Files:</strong>
+  <%= @job&.files || '--' %>
+</p></div>
+
+<table class="job">
+  <thead>
+    <td class="identifier">Identifier</td>
+    <td class="lineno">Row</td>
+    <td class="type">Type</td>
+    <td class="visibility">Visibility</td>
+    <td class="collection_count">cs</td>
+    <td class="work_count">ws</td>
+    <td class="file_count">fs</td>
+    <td class="index">Order</td>
+    <td class="title">title <span class="file-name">/ filename</span></td>
+    <td class="filename">filename</td>
+  </thead>
+  <tbody></tbody>
+</table>
+    <% @root.children.each do |child| %>
+      <%= render "child", node: child, parent: "0", depth: 0 %>
+    <% end %>
+
+<br/>
+<%= link_to 'Back', jobs_path, class: 'btn btn-default ' %>

--- a/spec/requests/preflight_request_spec.rb
+++ b/spec/requests/preflight_request_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "/preflights", type: :request do
       get preflight_path Job.last
       expect(response).to render_template('preflights/show')
       expect(response.body).to match(/preflight-warnings/)
-      expect(response.body).to match(/Could not find parent work &quot;NONEXISTENT&quot;/)
+      expect(response.body).to match(/Could not find parent work or collection &quot;NONEXISTENT&quot;/)
     end
   end
 

--- a/spec/views/imports/show.html.erb_spec.rb
+++ b/spec/views/imports/show.html.erb_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe "imports/show", type: :view do
+  let(:admin) { FactoryBot.create(:user) }
+  let(:tempfile) { fixture_file_upload('csv/empty.csv') }
+  let(:completion_time) { Time.current.round }
+  let(:import_job) { Import.new(user: admin, parent_job: preflight) }
+  let(:preflight) {
+    Preflight.new(
+      id: 8_675_309,
+      user: admin,
+      manifest: tempfile,
+      status: :completed,
+      completed_at: completion_time,
+      works: 13,
+      files: 17
+    )
+  }
+
+  it "renders attributes", :aggregate_failures do
+    @job = import_job
+    @root = Tenejo::Graph.new.root
+    render
+    expect(rendered).to have_selector('#import-user', text: admin)
+    expect(rendered).to have_selector('#import-manifest', text: 'empty.csv')
+    expect(rendered).to have_selector('#import-status', text: 'Unknown')
+    expect(rendered).to have_selector('#import-created_at', text: import_job.created_at)
+    expect(rendered).to have_selector('#import-completed_at', text: '--')
+    expect(rendered).to have_selector('#import-collections', text: '--')
+    expect(rendered).to have_selector('#import-works', text: '--')
+    expect(rendered).to have_selector('#import-files', text: '--')
+    expect(rendered).to have_link(text: 'empty.csv')
+  end
+
+  it "handles missing attributes gracefully" do
+    @job = nil
+    @root = Tenejo::Graph.new.root
+    expect { render }.not_to raise_error
+  end
+
+  it "shows any errors" do
+    pending "accumulate import errors"
+    render
+    expect(rendered).to have_selector('.import-errors', text: 'Virus detected')
+  end
+
+  it "shows any warnings", :aggregate_failures do
+    pending "accumulate import warnings"
+    render
+    expect(rendered).to have_selector('.import-warnings', text: 'Warnings')
+    expect(rendered).to have_selector('li', text: 'Could not find parent work', count: 2)
+  end
+
+  it "shows any collections", :aggregate_failures do
+    pending "Finalize import/show UI layout"
+    expect(rendered).to have_selector('tr td', text: 'Collection...')
+  end
+
+  it "shows any works", :aggregate_failures do
+    pending "Finalize import/show UI layout"
+    expect(rendered).to have_selector('tr td', text: 'Work...')
+  end
+
+  it "shows any files", :aggregate_failures do
+    pending "Finalize import/show UI layout"
+    expect(rendered).to have_selector('tr td', text: 'File...')
+  end
+end


### PR DESCRIPTION
Implements a collapsible table to show the structural
relationship between collections, works, and files in an import job.

**BEFORE**
![image](https://user-images.githubusercontent.com/3064318/151043612-6780419c-ab04-466a-a746-9cba1b0a495b.png)


**AFTER**
![import_status](https://user-images.githubusercontent.com/3064318/151043131-b175018a-ae78-421e-b9ab-97b34d8d30bc.gif)
