### PR TITLE
Update Preflight and Import to set visibility

### DIFF
--- a/spec/fixtures/csv/structure_test.csv
+++ b/spec/fixtures/csv/structure_test.csv
@@ -13,6 +13,8 @@
 ,,,,,,,,,
 "CARDS-0001-J","Work","CARDS-0001","Jokers","Child work with packed file list","T. C. Oyun Kagitlari Monopolu","Copyright Not Evaluated","public","Joker1-Recto.tiff|~|Joker1-Verso.tiff|~|Joker2-Recto.tiff|~|Joker2-Verso.tiff",
 ,,,,,,,,,
+"DARK","c","EPHEM","Non-public Materials","Child collection, private (restricted) visiblity",,,"restricted",,
+,,,,,,,,,
 "CARDS-0001-D","Work","CARDS-0001","Diamonds","Child work with no direct files","T. C. Oyun Kagitlari Monopolu","Copyright Not Evaluated","public",,
 "CARDS-0001-D-A","File","CARDS-0001-D","Ace of Diamonds","File with packed file list","T. C. Oyun Kagitlari Monopolu","Copyright Not Evaluated","public","As-Carreaux-Recto.tiff|~|As-Carreaux-Verso.tiff",
 "CARDS-0001-D-J","File","CARDS-0001-D","Jack of Diamonds","File with packed file list","T. C. Oyun Kagitlari Monopolu","Copyright Not Evaluated","public","Valet-Carreaux-Recto.tiff|~|Valet-Carreaux-Verso.tiff",

--- a/spec/lib/tenejo/csv_importer_spec.rb
+++ b/spec/lib/tenejo/csv_importer_spec.rb
@@ -36,28 +36,46 @@ RSpec.describe Tenejo::CsvImporter do
 
     csv_import.import
 
-    expect(csv_import).to have_received(:create_or_update_collection).exactly(2).times
+    expect(csv_import).to have_received(:create_or_update_collection).exactly(3).times
     expect(csv_import).to have_received(:create_or_update_work).exactly(12).times
     expect(csv_import).to have_received(:create_or_update_file).exactly(31).times
   end
 
-  it 'creates parent-child relationships', :aggregate_failures do
-    ActiveFedora::Cleaner.clean!
-    csv_import = described_class.new(import_job)
-    csv_import.import
+  context 'with a valid CSV' do
+    let(:csv) { fixture_file_upload("./spec/fixtures/csv/structure_test.csv") }
+    it 'builds the expected objects and relationships', :aggregate_failures do
+      ActiveFedora::Cleaner.clean!
+      described_class.reset_default_collection_type!
+      csv_import = described_class.new(import_job)
+      csv_import.import
 
-    parent = Collection.where(identifier: 'EPHEM').last
-    child = Collection.where(identifier: 'CARDS').last
-    grandchild = Work.where(identifier: 'CARDS-0001').find { |w| w.identifier == ['CARDS-0001'] }
-    greatgrandchild = Work.where(identifier: 'CARDS-0001-J').find { |w| w.identifier == ['CARDS-0001-J'] }
+      parent = Collection.where(identifier: 'EPHEM').first
+      child = Collection.where(identifier: 'CARDS').first
+      grandchild = Work.where(identifier: 'CARDS-0001').find { |w| w.identifier == ['CARDS-0001'] }
+      greatgrandchild = Work.where(identifier: 'CARDS-0001-J').find { |w| w.identifier == ['CARDS-0001-J'] }
 
-    expect(parent.child_collections).to include child
-    expect(child.parent_collections).to include parent
-    expect(child.child_collections).to be_empty
-    expect(child.child_works).to include grandchild
-    expect(greatgrandchild.parent_works).to include grandchild
+      expect(parent.child_collections).to include child
+      expect(child.parent_collections).to include parent
+      expect(child.child_collections).to be_empty
+      expect(child.child_works).to include grandchild
+      expect(greatgrandchild.parent_works).to include grandchild
 
-    expect(Work.where(identifier: 'CARDS-0001').count).to be > 1, "remember to simplify these test when identifier is refactored"
+      private_work = Work.where(identifier: 'ORPH-0001').find { |w| w.identifier == ['ORPH-0001'] }
+      institutional_work = Work.where(identifier: 'ORPH-0002').find { |w| w.identifier == ['ORPH-0002'] }
+      public_work = Work.where(identifier: 'CARDS-0001-J').find { |w| w.identifier == ['CARDS-0001-J'] }
+
+      expect(private_work.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+      expect(institutional_work.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+      expect(public_work.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+
+      private_collection = Collection.where(identifier: 'DARK').first
+      public_collection = Collection.where(identifier: 'CARDS').find { |w| w.identifier == ['CARDS'] }
+
+      expect(private_collection.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+      expect(public_collection.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+
+      expect(Work.where(identifier: 'CARDS-0001').count).to be > 1, "remember to simplify these test when identifier is refactored"
+    end
   end
 
   context '.create_or_update_collection' do


### PR DESCRIPTION
Visibility is a pseudo-attribute that does not appear in the data
model in the same way other fields do.  Visiblity, therefore, needs
special handling in preflight and import.

The current code accepts the following values in the CSV
* "open" or "public" give everyone access to the item regardless of
login status
* "authenticated" requires a user to be logged in tp view the item
* "private" or "restricted" items can only be viewed by repository
administrators
* Any other value, including blanks, will set the visilbilty to "private"