### PR TITLE
Refactor csv test

### DIFF
--- a/spec/lib/tenejo/csv_importer_nesting_spec.rb
+++ b/spec/lib/tenejo/csv_importer_nesting_spec.rb
@@ -28,34 +28,36 @@ RSpec.describe Tenejo::CsvImporter do
     conn.rollback_transaction if conn.transaction_open?
   end
 
-  context 'with a valid CSV' do
-    it 'builds the expected objects and relationships', :aggregate_failures do
-      parent = Collection.where(primary_identifier: 'EPHEM').first
-      child = Collection.where(primary_identifier: 'CARDS').first
-      grandchild = Work.where(primary_identifier: 'CARDS-0001').find { |w| w.identifier == ['CARDS-0001'] }
-      greatgrandchild = Work.where(primary_identifier: 'CARDS-0001-J').find { |w| w.identifier == ['CARDS-0001-J'] }
+  it 'builds relationships', :aggregate_failures do
+    parent = Collection.where(primary_identifier: 'EPHEM').first
+    child = Collection.where(primary_identifier: 'CARDS').first
+    grandchild = Work.where(primary_identifier: 'CARDS-0001').find { |w| w.identifier == ['CARDS-0001'] }
+    greatgrandchild = Work.where(primary_identifier: 'CARDS-0001-J').find { |w| w.identifier == ['CARDS-0001-J'] }
 
-      expect(parent.child_collections).to include child
-      expect(child.parent_collections).to include parent
-      expect(child.child_collections).to be_empty
-      expect(child.child_works).to include grandchild
-      expect(greatgrandchild.parent_works).to include grandchild
+    expect(parent.child_collections).to include child
+    expect(child.parent_collections).to include parent
+    expect(child.child_collections).to be_empty
+    expect(child.child_works).to include grandchild
+    expect(greatgrandchild.parent_works).to include grandchild
+  end
 
-      private_work = Work.where(primary_identifier: 'ORPH-0001').find { |w| w.identifier == ['ORPH-0001'] }
-      institutional_work = Work.where(primary_identifier: 'ORPH-0002').find { |w| w.identifier == ['ORPH-0002'] }
-      public_work = Work.where(primary_identifier: 'CARDS-0001-J').find { |w| w.identifier == ['CARDS-0001-J'] }
+  it 'sets work-level visibility', :aggregate_failures do
+    private_work = Work.where(primary_identifier: 'ORPH-0001').find { |w| w.identifier == ['ORPH-0001'] }
+    institutional_work = Work.where(primary_identifier: 'ORPH-0002').find { |w| w.identifier == ['ORPH-0002'] }
+    public_work = Work.where(primary_identifier: 'CARDS-0001-J').find { |w| w.identifier == ['CARDS-0001-J'] }
 
-      expect(private_work.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
-      expect(institutional_work.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
-      expect(public_work.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+    expect(private_work.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+    expect(institutional_work.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+    expect(public_work.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
 
-      private_collection = Collection.where(primary_identifier: 'DARK').first
-      public_collection = Collection.where(primary_identifier: 'CARDS').find { |w| w.identifier == ['CARDS'] }
+    expect(Work.where(primary_identifier: 'CARDS-0001').count).to be > 1, "remember to simplify these test when identifier is refactored"
+  end
 
-      expect(private_collection.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
-      expect(public_collection.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+  it 'sets collection-level visibility', :aggregate_failures do
+    private_collection = Collection.where(primary_identifier: 'DARK').first
+    public_collection = Collection.where(primary_identifier: 'CARDS').find { |w| w.identifier == ['CARDS'] }
 
-      expect(Work.where(primary_identifier: 'CARDS-0001').count).to be > 1, "remember to simplify these test when identifier is refactored"
-    end
+    expect(private_collection.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+    expect(public_collection.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
   end
 end

--- a/spec/lib/tenejo/csv_importer_nesting_spec.rb
+++ b/spec/lib/tenejo/csv_importer_nesting_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+require 'csv'
+require 'rails_helper'
+require 'active_fedora/cleaner'
+
+RSpec.describe Tenejo::CsvImporter do
+  before :all do
+    # this nonsense is to create relevant files so that the preflighter will not reject the records
+    r = CSV.read('spec/fixtures/csv/structure_test.csv')
+    FileUtils.mkdir_p('tmp/test/uploads')
+    r.map { |z| z[8] }.reject(&:nil?).map { |t| t.split('|~|') }.flatten.reject { |k| k == 'Files' }.each do |f|
+      FileUtils.touch("tmp/test/uploads/#{f}")
+    end
+  end
+  let(:job_owner) { FactoryBot.create(:user) }
+  let(:csv) { fixture_file_upload("./spec/fixtures/csv/structure_test.csv") }
+  let(:preflight) { Preflight.create!(user: job_owner, manifest: csv) }
+  let(:import_job)  { Import.create!(user: job_owner, parent_job: preflight) }
+
+  context 'with a valid CSV' do
+    let(:csv) { fixture_file_upload("./spec/fixtures/csv/structure_test.csv") }
+    it 'builds the expected objects and relationships', :aggregate_failures do
+      ActiveFedora::Cleaner.clean!
+      described_class.reset_default_collection_type!
+      csv_import = described_class.new(import_job)
+      csv_import.import
+
+      parent = Collection.where(primary_identifier: 'EPHEM').first
+      child = Collection.where(primary_identifier: 'CARDS').first
+      grandchild = Work.where(primary_identifier: 'CARDS-0001').find { |w| w.identifier == ['CARDS-0001'] }
+      greatgrandchild = Work.where(primary_identifier: 'CARDS-0001-J').find { |w| w.identifier == ['CARDS-0001-J'] }
+
+      expect(parent.child_collections).to include child
+      expect(child.parent_collections).to include parent
+      expect(child.child_collections).to be_empty
+      expect(child.child_works).to include grandchild
+      expect(greatgrandchild.parent_works).to include grandchild
+
+      private_work = Work.where(primary_identifier: 'ORPH-0001').find { |w| w.identifier == ['ORPH-0001'] }
+      institutional_work = Work.where(primary_identifier: 'ORPH-0002').find { |w| w.identifier == ['ORPH-0002'] }
+      public_work = Work.where(primary_identifier: 'CARDS-0001-J').find { |w| w.identifier == ['CARDS-0001-J'] }
+
+      expect(private_work.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+      expect(institutional_work.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+      expect(public_work.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+
+      private_collection = Collection.where(primary_identifier: 'DARK').first
+      public_collection = Collection.where(primary_identifier: 'CARDS').find { |w| w.identifier == ['CARDS'] }
+
+      expect(private_collection.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+      expect(public_collection.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+
+      expect(Work.where(primary_identifier: 'CARDS-0001').count).to be > 1, "remember to simplify these test when identifier is refactored"
+    end
+  end
+end

--- a/spec/lib/tenejo/csv_importer_spec.rb
+++ b/spec/lib/tenejo/csv_importer_spec.rb
@@ -4,14 +4,6 @@ require 'rails_helper'
 require 'active_fedora/cleaner'
 
 RSpec.describe Tenejo::CsvImporter do
-  before :all do
-    # this nonsense is to create relevant files so that the preflighter will not reject the records
-    r = CSV.read('spec/fixtures/csv/structure_test.csv')
-    FileUtils.mkdir_p('tmp/test/uploads')
-    r.map { |z| z[8] }.reject(&:nil?).map { |t| t.split('|~|') }.flatten.reject { |k| k == 'Files' }.each do |f|
-      FileUtils.touch("tmp/test/uploads/#{f}")
-    end
-  end
   let(:job_owner) { FactoryBot.create(:user) }
   let(:csv) { fixture_file_upload("./spec/fixtures/csv/structure_test.csv") }
   let(:preflight) { Preflight.create!(user: job_owner, manifest: csv) }
@@ -39,43 +31,6 @@ RSpec.describe Tenejo::CsvImporter do
     expect(csv_import).to have_received(:create_or_update_collection).exactly(3).times
     expect(csv_import).to have_received(:create_or_update_work).exactly(12).times
     expect(csv_import).to have_received(:create_or_update_file).exactly(31).times
-  end
-
-  context 'with a valid CSV' do
-    let(:csv) { fixture_file_upload("./spec/fixtures/csv/structure_test.csv") }
-    it 'builds the expected objects and relationships', :aggregate_failures do
-      ActiveFedora::Cleaner.clean!
-      described_class.reset_default_collection_type!
-      csv_import = described_class.new(import_job)
-      csv_import.import
-
-      parent = Collection.where(primary_identifier: 'EPHEM').first
-      child = Collection.where(primary_identifier: 'CARDS').first
-      grandchild = Work.where(primary_identifier: 'CARDS-0001').find { |w| w.identifier == ['CARDS-0001'] }
-      greatgrandchild = Work.where(primary_identifier: 'CARDS-0001-J').find { |w| w.identifier == ['CARDS-0001-J'] }
-
-      expect(parent.child_collections).to include child
-      expect(child.parent_collections).to include parent
-      expect(child.child_collections).to be_empty
-      expect(child.child_works).to include grandchild
-      expect(greatgrandchild.parent_works).to include grandchild
-
-      private_work = Work.where(primary_identifier: 'ORPH-0001').find { |w| w.identifier == ['ORPH-0001'] }
-      institutional_work = Work.where(primary_identifier: 'ORPH-0002').find { |w| w.identifier == ['ORPH-0002'] }
-      public_work = Work.where(primary_identifier: 'CARDS-0001-J').find { |w| w.identifier == ['CARDS-0001-J'] }
-
-      expect(private_work.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
-      expect(institutional_work.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
-      expect(public_work.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
-
-      private_collection = Collection.where(primary_identifier: 'DARK').first
-      public_collection = Collection.where(primary_identifier: 'CARDS').find { |w| w.identifier == ['CARDS'] }
-
-      expect(private_collection.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
-      expect(public_collection.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
-
-      expect(Work.where(primary_identifier: 'CARDS-0001').count).to be > 1, "remember to simplify these test when identifier is refactored"
-    end
   end
 
   context '.create_or_update_collection' do


### PR DESCRIPTION
* Split CSV nesting tests into a separate file
* Refactor expensive test setup to only run once
* Split large test into smaller examples