### PR TITLE
Revert move of file setup for CSV test

### DIFF
--- a/spec/lib/tenejo/csv_importer_spec.rb
+++ b/spec/lib/tenejo/csv_importer_spec.rb
@@ -4,6 +4,15 @@ require 'rails_helper'
 require 'active_fedora/cleaner'
 
 RSpec.describe Tenejo::CsvImporter do
+  before :all do
+    # this nonsense is to create relevant files so that the preflighter will not reject the records
+    r = CSV.read('spec/fixtures/csv/structure_test.csv')
+    FileUtils.mkdir_p('tmp/test/uploads')
+    r.map { |z| z[8] }.reject(&:nil?).map { |t| t.split('|~|') }.flatten.reject { |k| k == 'Files' }.each do |f|
+      FileUtils.touch("tmp/test/uploads/#{f}")
+    end
+  end
+
   let(:job_owner) { FactoryBot.create(:user) }
   let(:csv) { fixture_file_upload("./spec/fixtures/csv/structure_test.csv") }
   let(:preflight) { Preflight.create!(user: job_owner, manifest: csv) }


### PR DESCRIPTION
On a local system, this setup runs and leaves the files in place,
so after one run of the test suite, the expected files are always
available for all tests.

When running in parallel on CI, the files don't persist and might
be running on a container that hasn't had the setup from other
CSV tests run yet.

So I'm adding back the explict file setup so CSVs validate as
expected.