### PR TITLE
Update bunder for CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
                 default: 2.7.4
             bundler_version:
                 type: string
-                default: 2.2.29
+                default: 2.2.33
         environment:
           DATABASE_URL: postgresql://postgres@127.0.0.1/circle_test
           DATABASE_NAME: circle_test


### PR DESCRIPTION
Addresses the following warning in CircleCI
```
Warning: the running version of Bundler (2.2.29)
is older than the version that created the lockfile (2.2.33).
We suggest you to upgrade to the version that created the lockfile
by running `gem install bundler:2.2.33`
```