### PR TITLE
Improve datatable sort arrow placement

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -10,9 +10,9 @@
  * files in this directory. Styles in this file should be added after the last require_* statement.
  * It is generally better to create a new file per style scope.
  *
- *= require_tree .
- *= require dataTables/bootstrap/3/jquery.dataTables.bootstrap
  *= require_self
+ *= require 'datatables'
+ *= require_tree .
  */
 
 .site-footer {

--- a/app/assets/stylesheets/datatables.css
+++ b/app/assets/stylesheets/datatables.css
@@ -1,0 +1,18 @@
+/* DataTable Icon Sort Icons */
+th::after {
+    padding-left: 0.5rem;
+    font-family: 'FontAwesome';
+}
+
+th.sorting::after {
+    color: lightgrey;
+    content: "\f0dc";
+}
+
+th.sorting_desc::after {
+    content: "\f0dd";
+}
+
+th.sorting_asc::after {
+    content: "\f0de";
+}


### PR DESCRIPTION
This change represents a minimalist solution to move the sort selection
arrows for data tables to be adjacent to the header text (instead of
right justified at the end of the column).

* For information on css load order:
   https://guides.rubyonrails.org/asset_pipeline.html#manifest-files-and-directives

* For information on embedding FontAwesome icons in pseudo-elements:
   https://fontawesome.com/v5.15/how-to-use/on-the-web/advanced/css-pseudo-elements

* For unicode values, select a specific icon and look for the unicode next to
    the class name: https://fontawesome.com/v4.7/icons/

![image](https://user-images.githubusercontent.com/3064318/152269146-a3b7cb23-2bac-486a-ad6f-4b44211a9242.png)
