### PR TITLE
Fix detection of invalid items

### DIFF
--- a/app/lib/tenejo/csv_importer.rb
+++ b/app/lib/tenejo/csv_importer.rb
@@ -13,6 +13,18 @@ module Tenejo
       @csv_import_file_root = Hyrax.config.upload_path.call.to_s
     end
 
+    def preflight_errors
+      @graph.fatal_errors
+    end
+
+    def preflight_warnings
+      @graph.warnings
+    end
+
+    def invalid_rows
+      @graph.invalids
+    end
+
     def import
       return if fatal_errors(@graph)
       @graph.root.children.each do |child|

--- a/app/lib/tenejo/graph.rb
+++ b/app/lib/tenejo/graph.rb
@@ -78,19 +78,12 @@ class Tenejo::Graph
   end
 
   def reject_invalid
-    invalids = [@works, @collections, @files].each do |n|
-      n.each_with_object({}) do |x, m|
-        invalids = n.select { |y| !y.valid? }
-        invalids.each { |y| n.delete(y) }
-        m[x] = invalids
-        m
-      end
-    end
-    invalids.flatten.each do |k|
-      @warnings << "Invalid #{k} item: #{k.errors.full_messages.join(',')} on line #{k.lineno}"
-    end
-    @invalids = invalids.flatten
-    self
+    @collections, invalid_collections = @collections.partition(&:valid?)
+    @works, invalid_works = @works.partition(&:valid?)
+    @files, invalid_files = @files.partition(&:valid?)
+    @invalids = invalid_collections + invalid_works + invalid_files
+    @warnings += @invalids.map { |k| "Invalid #{k} item: #{k.errors.full_messages.join(',')} on line #{k.lineno}" }
   end
+
   DEFAULT_UPLOAD_PATH = ENV.fetch('UPLOAD_PATH', Rails.root.join('tmp', 'uploads'))
 end


### PR DESCRIPTION
The previous implementation of `reject_invalids` incorrectly
flagged all rows in the CSV.  This change simplifies the validation
and correctly detects and removes invalid items from the
validated graph.