### PR TITLE
Allow unique matches on primary_identifier

### DIFF
--- a/app/lib/tenejo/csv_importer.rb
+++ b/app/lib/tenejo/csv_importer.rb
@@ -61,7 +61,7 @@ module Tenejo
       collection = find_or_new_collection(pfcollection.identifier, pfcollection.title)
       update_collection_attributes(collection, pfcollection)
       if pfcollection.parent
-        parent = Collection.where(primary_identifier: pfcollection.parent).first
+        parent = Collection.where(primary_identifier_ssi: pfcollection.parent).first
         collection.member_of_collections << parent
       end
       save_collection(collection)
@@ -70,7 +70,7 @@ module Tenejo
     # Finds or creates a collection by its user supplied identifier
     # returns a valid collection or nil
     def find_or_new_collection(primary_id, title)
-      collection_found = Collection.where(primary_identifier: primary_id).last
+      collection_found = Collection.where(primary_identifier_ssi: primary_id).last
       return collection_found if collection_found
       Collection.new(
         primary_identifier: primary_id.first,
@@ -98,7 +98,7 @@ module Tenejo
 
       # set the collection parent relationship
       return unless pfcollection.parent
-      parent = Collection.where(primary_identifier: pfcollection.parent).first
+      parent = Collection.where(primary_identifier_ssi: pfcollection.parent).first
       collection.member_of_collections << parent
     end
 
@@ -122,7 +122,7 @@ module Tenejo
     # Finds or creates a work by its user supplied identifier
     # returns a valid work or nil
     def find_or_new_work(primary_id, title)
-      work_found = Work.where(primary_identifier: primary_id).last
+      work_found = Work.where(primary_identifier_ssi: primary_id).last
       return work_found if work_found
       Work.new(
         primary_identifier: primary_id.first,
@@ -151,10 +151,10 @@ module Tenejo
       return unless pfwork.parent
       # Works can have either collections OR other works as their parents
       # for collections, set the relationship on the work
-      parent_collection = Collection.where(primary_identifier: pfwork.parent).first
+      parent_collection = Collection.where(primary_identifier_ssi: pfwork.parent).first
       work.member_of_collections << parent_collection if parent_collection
       # for works, set the relationship on the parent work
-      parent_work = Work.where(primary_identifier: pfwork.parent).first
+      parent_work = Work.where(primary_identifier_ssi: pfwork.parent).first
       parent_work.ordered_members << work if parent_work
       parent_work&.save!
       # if we need to make this code faster,

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -312,4 +312,3 @@ Date::DATE_FORMATS[:standard] = "%m/%d/%Y"
 Qa::Authorities::Local.register_subauthority('subjects', 'Qa::Authorities::Local::TableBasedAuthority')
 Qa::Authorities::Local.register_subauthority('languages', 'Qa::Authorities::Local::TableBasedAuthority')
 Qa::Authorities::Local.register_subauthority('genres', 'Qa::Authorities::Local::TableBasedAuthority')
-Hyrax::BasicMetadataIndexer.stored_fields << :primary_identifier

--- a/spec/lib/tenejo/csv_importer_nesting_spec.rb
+++ b/spec/lib/tenejo/csv_importer_nesting_spec.rb
@@ -29,10 +29,10 @@ RSpec.describe Tenejo::CsvImporter do
   end
 
   it 'builds relationships', :aggregate_failures do
-    parent = Collection.where(primary_identifier: 'EPHEM').first
-    child = Collection.where(primary_identifier: 'CARDS').first
-    grandchild = Work.where(primary_identifier: 'CARDS-0001').find { |w| w.identifier == ['CARDS-0001'] }
-    greatgrandchild = Work.where(primary_identifier: 'CARDS-0001-J').find { |w| w.identifier == ['CARDS-0001-J'] }
+    parent = Collection.where(primary_identifier_ssi: 'EPHEM').first
+    child = Collection.where(primary_identifier_ssi: 'CARDS').first
+    grandchild = Work.where(primary_identifier_ssi: 'CARDS-0001').first
+    greatgrandchild = Work.where(primary_identifier_ssi: 'CARDS-0001-J').first
 
     expect(parent.child_collections).to include child
     expect(child.parent_collections).to include parent
@@ -42,20 +42,18 @@ RSpec.describe Tenejo::CsvImporter do
   end
 
   it 'sets work-level visibility', :aggregate_failures do
-    private_work = Work.where(primary_identifier: 'ORPH-0001').find { |w| w.identifier == ['ORPH-0001'] }
-    institutional_work = Work.where(primary_identifier: 'ORPH-0002').find { |w| w.identifier == ['ORPH-0002'] }
-    public_work = Work.where(primary_identifier: 'CARDS-0001-J').find { |w| w.identifier == ['CARDS-0001-J'] }
+    private_work = Work.where(primary_identifier_ssi: 'ORPH-0001').first
+    institutional_work = Work.where(primary_identifier_ssi: 'ORPH-0002').first
+    public_work = Work.where(primary_identifier_ssi: 'CARDS-0001-J').first
 
     expect(private_work.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
     expect(institutional_work.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
     expect(public_work.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
-
-    expect(Work.where(primary_identifier: 'CARDS-0001').count).to be > 1, "remember to simplify these test when identifier is refactored"
   end
 
   it 'sets collection-level visibility', :aggregate_failures do
-    private_collection = Collection.where(primary_identifier: 'DARK').first
-    public_collection = Collection.where(primary_identifier: 'CARDS').find { |w| w.identifier == ['CARDS'] }
+    private_collection = Collection.where(primary_identifier_ssi: 'DARK').first
+    public_collection = Collection.where(primary_identifier_ssi: 'CARDS').first
 
     expect(private_collection.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
     expect(public_collection.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC

--- a/spec/lib/tenejo/csv_importer_spec.rb
+++ b/spec/lib/tenejo/csv_importer_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Tenejo::CsvImporter do
       # these tests are expensive, try to minimize how many we need to run
       before do
         # Ensure a collection with the expected :identifier does not exist
-        # Collection.where(primary_identifier: 'TEST0001').to_a.each { |c| c.destroy(eradicate: true) }
+        # Collection.where(primary_identifier_ssi: 'TEST0001').to_a.each { |c| c.destroy(eradicate: true) }
         ActiveFedora::Cleaner.clean!
         described_class.reset_default_collection_type!
       end
@@ -67,8 +67,8 @@ RSpec.describe Tenejo::CsvImporter do
 
       it "creates a new collection", :aggregate_failures do
         csv_import = described_class.new(import_job)
-        expect { csv_import.create_or_update_collection(pf_collection) }.to change { Collection.where(primary_identifier: 'TEST0001').count }.from(0).to(1)
-        collection = Collection.where(primary_identifier: 'TEST0001').last
+        expect { csv_import.create_or_update_collection(pf_collection) }.to change { Collection.where(primary_identifier_ssi: 'TEST0001').count }.from(0).to(1)
+        collection = Collection.where(primary_identifier_ssi: 'TEST0001').last
         expect(collection.depositor).to eq job_owner.user_key
         expect(collection.date_uploaded.in_time_zone).to be_within(1.minute).of Time.current
         expect(collection.title).to eq pf_collection.title
@@ -95,13 +95,13 @@ RSpec.describe Tenejo::CsvImporter do
 
       it "uses the existing collection instead of creating a new one" do
         csv_import = described_class.new(import_job)
-        expect { csv_import.create_or_update_collection(pf_collection) }.not_to change { Collection.where(primary_identifier: 'TEST0002').count }
+        expect { csv_import.create_or_update_collection(pf_collection) }.not_to change { Collection.where(primary_identifier_ssi: 'TEST0002').count }
       end
 
       it "sets administrative data", :aggregate_failures do
         csv_import = described_class.new(import_job)
         csv_import.create_or_update_collection(pf_collection)
-        collection = Collection.where(primary_identifier: 'TEST0002').last
+        collection = Collection.where(primary_identifier_ssi: 'TEST0002').last
         expect(collection.depositor).not_to be_nil
         expect(collection.date_uploaded).to eq '2020-07-01 12:30:05' # should not be changed
         expect(collection.date_modified.in_time_zone).to be_within(1.minute).of Time.current
@@ -126,7 +126,7 @@ RSpec.describe Tenejo::CsvImporter do
         it "updates all of them", :aggregate_failures do
           csv_import = described_class.new(import_job)
           csv_import.create_or_update_collection(pf_collection)
-          collection = Collection.where(primary_identifier: 'TEST0002').last
+          collection = Collection.where(primary_identifier_ssi: 'TEST0002').last
 
           # Most settings should be updated by the import
           # TODO: the next two lines will break if/when any settable attributes are not multi-valued in the model
@@ -154,8 +154,8 @@ RSpec.describe Tenejo::CsvImporter do
 
       it "creates a new work", :aggregate_failures do
         csv_import = described_class.new(import_job)
-        expect { csv_import.create_or_update_work(pf_work) }.to change { Work.where(primary_identifier: 'WORK-0001').count }.from(0).to(1)
-        work = Work.where(primary_identifier: 'WORK-0001').last
+        expect { csv_import.create_or_update_work(pf_work) }.to change { Work.where(primary_identifier_ssi: 'WORK-0001').count }.from(0).to(1)
+        work = Work.where(primary_identifier_ssi: 'WORK-0001').last
         expect(work.depositor).to eq job_owner.user_key
         expect(work.date_uploaded.in_time_zone).to be_within(1.minute).of Time.current
         expect(work.title).to eq pf_work.title
@@ -182,13 +182,13 @@ RSpec.describe Tenejo::CsvImporter do
 
       it "uses the existing work instead of creating a new one" do
         csv_import = described_class.new(import_job)
-        expect { csv_import.create_or_update_work(pf_work) }.not_to change { Work.where(primary_identifier: 'WORK-0002').count }
+        expect { csv_import.create_or_update_work(pf_work) }.not_to change { Work.where(primary_identifier_ssi: 'WORK-0002').count }
       end
 
       it "sets administrative data", :aggregate_failures do
         csv_import = described_class.new(import_job)
         csv_import.create_or_update_work(pf_work)
-        work = Work.where(primary_identifier: 'WORK-0002').last
+        work = Work.where(primary_identifier_ssi: 'WORK-0002').last
         expect(work.depositor).not_to be_nil
         expect(work.date_uploaded).to eq '2020-07-01 12:30:05' # should not be changed
         expect(work.date_modified.in_time_zone).to be_within(1.minute).of Time.current
@@ -213,7 +213,7 @@ RSpec.describe Tenejo::CsvImporter do
         it "updates all of them", :aggregate_failures do
           csv_import = described_class.new(import_job)
           csv_import.create_or_update_work(pf_work)
-          work = Work.where(primary_identifier: 'WORK-0002').last
+          work = Work.where(primary_identifier_ssi: 'WORK-0002').last
 
           # Most settings should be updated by the import
           # TODO: the next two lines will break if/when any settable attributes are not multi-valued in the model

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -16,4 +16,11 @@ RSpec.describe Work do
     expect(described_class.editable_terms).to include(:creator)
     expect(described_class.editable_terms).not_to include(:date_uploaded)
   end
+
+  it 'does not tokenize primary_identifier' do
+    work = described_class.new(primary_identifier: "TESTING-123")
+    solr_doc = work.indexing_service.generate_solr_document
+    expect(solr_doc.keys).to include "primary_identifier_ssi"
+    expect(solr_doc["primary_identifier_ssi"]).to eq "TESTING-123"
+  end
 end


### PR DESCRIPTION
Including primary_identifier in Hyrax::BasicMetadataIndexer.stored_fields
caused it to ignore the symbol and multiple: false setting in
the property definition and cause it to be tokenized with a _tesim
suffix instead.

This change removes the stored_fields setting and updates all searches
to use the explicilty suffixed _ssi Solr fieldname instead.

This allows us to do exact and unique matches on `primary_identifier`
even when two or more primary_identifiers share common prefix segements.