### PR TITLE
Visibility language

### DIFF
--- a/config/locales/hyrax.de.yml
+++ b/config/locales/hyrax.de.yml
@@ -52,7 +52,7 @@ de:
     footer:
       copyright_html: "<strong>Copyright © 2018 Samvera lizenziert</strong> unter der Apache Lizenz, Version 2.0"
       service_html: Ein Dienst von <a href="http://samvera.org/" class="navbar-link" target="_blank">Samvera</a> .
-    institution_name: Institution
+    institution_name: Begrenzung
     institution_name_full: Name des Instituts
     product_name: Hyrax
     product_twitter_handle: "@SamveraRepo"

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -52,10 +52,29 @@ en:
     footer:
       copyright_html: "<strong>Copyright &copy; 2018 Samvera</strong> Licensed under the Apache License, Version 2.0"
       service_html: A service of <a href="http://samvera.org/" class="navbar-link" target="_blank">Samvera</a>.
-    institution_name: Institution
+    institution_name: Restricted
     institution_name_full: The Institution Name
     product_name: Hyrax
     product_twitter_handle: "@SamveraRepo"
+    visibility:
+      authenticated:
+        note_html: Only visible to logged in users.
+        text: Restricted
+      embargo:
+        note_html: Set date for future release.
+        text: Embargo
+      lease:
+        note_html: Set date for future reduced access.
+        text: Lease
+      open:
+        note_html: Visible to any user regardless of login status
+        text: Public
+        warning_html: '<p> <strong>Please note</strong>, making something visible to the world (i.e. marking this as %{label}) may be viewed as publishing which could impact your ability to: </p> <ul> <li>Patent your work</li> <li>Publish your work in a journal</li> </ul> <p> Check out <a href="http://www.sherpa.ac.uk/romeo/">SHERPA/RoMEO</a> for more information about publisher copyright policies. </p>'
+      open_title_attr: Change the visibility of this resource
+      restricted:
+        note_html: Only visible to Administrators and myself with option to share.
+        text: Private
+      restricted_title_attr: Change the visibility of this resource
     homepage:
       admin_sets:
         title: Highlights
@@ -68,6 +87,16 @@ en:
           create: Create New User
       sidebar:
         users: Users & Roles
+      admin_sets:
+        form_visibility:
+          visibility:
+            description: Set visibility policies for the administrative set. Setting honors embargo policies above.
+            everyone: Public - depositor can only choose public visibility setting
+            institution: Restricted -- depositor can only select restricted visibility setting
+            restricted: Private -- depositor can only select private for visibility. Access is restricted to repository administrators, managers, and viewers of the set. Must be used with "No embargo" setting above.
+            title: Visibility
+            varies: All settings allowed -- depositor can choose. Must use this option to allow leases.
+
     search:
       button:
         html: <span class="fa fa-search" aria-hidden="true"></span> Search

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -52,7 +52,7 @@ es:
     footer:
       copyright_html: "<strong>Copyright &copy; 2018 Samvera</strong> bajo licencia de Apache, Version 2.0"
       service_html: Un servicio de <a href="http://samvera.org/" class="navbar-link" target="_blank">Samvera</a>.
-    institution_name: institución
+    institution_name: Restringido
     institution_name_full: El nombre de la institución
     product_name: Hyrax
     product_twitter_handle: "@SamveraRepo"

--- a/config/locales/hyrax.fr.yml
+++ b/config/locales/hyrax.fr.yml
@@ -52,7 +52,7 @@ fr:
     footer:
       copyright_html: "<strong>Copyright © 2018 Samvera</strong> Licence sous Licence Apache, Version 2.0"
       service_html: Un service de <a href="http://samvera.org/" class="navbar-link" target="_blank">Samvera</a> .
-    institution_name: Institution
+    institution_name: Limité
     institution_name_full: Nom de l'établissement
     product_name: Hyrax
     product_twitter_handle: "@SamveraRepo"

--- a/config/locales/hyrax.it.yml
+++ b/config/locales/hyrax.it.yml
@@ -52,7 +52,7 @@ it:
     footer:
       copyright_html: "<strong>Copyright © 2018 Samvera</strong> Licenza sotto la licenza Apache, versione 2.0"
       service_html: Un servizio di <a href="http://samvera.org/" class="navbar-link" target="_blank">Samvera</a> .
-    institution_name: Istituzione
+    institution_name: Limitato
     institution_name_full: Nome dell'Istituzione
     product_name: Hyrax
     product_twitter_handle: "@SamveraRepo"

--- a/config/locales/hyrax.pt-BR.yml
+++ b/config/locales/hyrax.pt-BR.yml
@@ -52,7 +52,7 @@ pt-BR:
     footer:
       copyright_html: "<strong>Copyright © 2018 Samvera </strong> Licenciado sob a Licença Apache, Versão 2.0"
       service_html: Um serviço de <a href="http://samvera.org/" class="navbar-link" target="_blank">Samvera</a> .
-    institution_name: Instituição
+    institution_name: Restrito
     institution_name_full: O Nome da Instituição
     product_name: Hyrax
     product_twitter_handle: "@SamveraRepo"

--- a/config/locales/hyrax.zh.yml
+++ b/config/locales/hyrax.zh.yml
@@ -52,7 +52,7 @@ zh:
     footer:
       copyright_html: "<strong>版权所有 &copy; 2018 Samvera</strong> 根据Apache许可证2.0版许可"
       service_html: 的服务<a href="http://samvera.org/" class="navbar-link" target="_blank">Samvera</a>.
-    institution_name: 机构
+    institution_name: 禁
     institution_name_full: 机构名称
     product_name: 蹄兔
     product_twitter_handle: "@SamveraRepo"


### PR DESCRIPTION
Visibility options for admin sets, collections and works were updated to include this language:

- Public = visible to any user regardless of login status
- Restricted = visible to logged in users
- Private = only visible to administrators 

• Changes "Institution" tags and labels to "Restricted" in all local i18n 