### PR TITLE
Remove delete role block

### DIFF
--- a/app/views/roles/edit.html.erb
+++ b/app/views/roles/edit.html.erb
@@ -19,7 +19,7 @@
           <%= bootstrap_form_tag url: role_management.role_users_path(@role) do |f| %>
             <%= f.text_field 'user_key', label: t('role-management.edit.user') %>
             <%= f.submit t('role-management.edit.add') %>
-            <%= link_to t('role-management.edit.cancel'), role_management.roles_path, class: 'btn btn-default' %>
+            <%= link_to t('role-management.edit.cancel'),  hyrax.admin_users_path(anchor: "roles"), class: 'btn btn-default' %>
           <% end %>
         </div>
       </div>

--- a/app/views/roles/edit.html.erb
+++ b/app/views/roles/edit.html.erb
@@ -10,9 +10,6 @@
       <div class="row">
         <div class="col-xs-8">
           <%= f.submit t('role-management.edit.update') %>
-          <% if can? :destroy, Role %>
-            <%= button_to t('role-management.edit.delete'), role_management.role_path(@role), method: :delete, class: 'btn btn-danger' %>
-          <% end %>
         </div>
       </div>
     <% end %>


### PR DESCRIPTION
Removes the ability to delete a role from the role edit page. Updates the redirect link on cancel for add user