### PR TITLE
Refactor to use same directories in preflight and csv importer

### DIFF
--- a/app/lib/tenejo/csv_importer.rb
+++ b/app/lib/tenejo/csv_importer.rb
@@ -10,7 +10,7 @@ module Tenejo
     end
 
     def csv_import_file_root
-      @csv_import_file_root = Hyrax.config.upload_path.call.to_s
+      Hyrax.config.upload_path.call
     end
 
     def preflight_errors

--- a/app/lib/tenejo/graph.rb
+++ b/app/lib/tenejo/graph.rb
@@ -85,5 +85,5 @@ class Tenejo::Graph
     @warnings += @invalids.map { |k| "Invalid #{k} item: #{k.errors.full_messages.join(',')} on line #{k.lineno}" }
   end
 
-  DEFAULT_UPLOAD_PATH = ENV.fetch('UPLOAD_PATH', Rails.root.join('tmp', 'uploads'))
+  DEFAULT_UPLOAD_PATH = Hyrax.config.upload_path.call
 end

--- a/app/lib/tenejo/preflight.rb
+++ b/app/lib/tenejo/preflight.rb
@@ -6,7 +6,7 @@ require 'tenejo/graph'
 
 module Tenejo
   KNOWN_HEADERS = Tenejo::PFWork::ALL_FIELDS + Tenejo::PFCollection::ALL_FIELDS + Tenejo::PFFile::ALL_FIELDS + [:object_type]
-  DEFAULT_UPLOAD_PATH = ENV.fetch('UPLOAD_PATH', Rails.root.join('tmp', 'uploads'))
+  DEFAULT_UPLOAD_PATH = Hyrax.config.upload_path.call
   class DuplicateColumnError < RuntimeError; end
   class MissingIdentifierError < RuntimeError; end
 

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -191,8 +191,8 @@ Hyrax.config do |config|
 
   # Temporary paths to hold uploads before they are ingested into FCrepo
   # These must be lambdas that return a Pathname. Can be configured separately
-  #  config.upload_path = ->() { Rails.root + 'tmp' + 'uploads' }
-  #  config.cache_path = ->() { Rails.root + 'tmp' + 'uploads' + 'cache' }
+   config.upload_path = ->() { ENV.fetch('UPLOAD_PATH')  }
+   config.cache_path = ->() { ENV.fetch('CACHE_PATH') }
 
   # Location on local file system where derivatives will be stored
   # If you use a multi-server architecture, this MUST be a shared volume


### PR DESCRIPTION
Ensures that development and production enviroments have consistent
path settings for preflight and csv imports.