### PR TITLE
Update CSV importer to be able to find FTP uploads

### DIFF
--- a/app/lib/tenejo/csv_importer.rb
+++ b/app/lib/tenejo/csv_importer.rb
@@ -10,7 +10,7 @@ module Tenejo
     end
 
     def csv_import_file_root
-      Hyrax.config.upload_path.call
+      File.join(Hyrax.config.upload_path.call, 'ftp')
     end
 
     def preflight_errors

--- a/app/lib/tenejo/graph.rb
+++ b/app/lib/tenejo/graph.rb
@@ -85,5 +85,5 @@ class Tenejo::Graph
     @warnings += @invalids.map { |k| "Invalid #{k} item: #{k.errors.full_messages.join(',')} on line #{k.lineno}" }
   end
 
-  DEFAULT_UPLOAD_PATH = Hyrax.config.upload_path.call
+  DEFAULT_UPLOAD_PATH = File.join(Hyrax.config.upload_path.call, 'ftp')
 end

--- a/app/lib/tenejo/preflight.rb
+++ b/app/lib/tenejo/preflight.rb
@@ -6,7 +6,7 @@ require 'tenejo/graph'
 
 module Tenejo
   KNOWN_HEADERS = Tenejo::PFWork::ALL_FIELDS + Tenejo::PFCollection::ALL_FIELDS + Tenejo::PFFile::ALL_FIELDS + [:object_type]
-  DEFAULT_UPLOAD_PATH = Hyrax.config.upload_path.call
+  DEFAULT_UPLOAD_PATH = File.join(Hyrax.config.upload_path.call, 'ftp')
   class DuplicateColumnError < RuntimeError; end
   class MissingIdentifierError < RuntimeError; end
 

--- a/spec/requests/preflight_request_spec.rb
+++ b/spec/requests/preflight_request_spec.rb
@@ -40,10 +40,10 @@ RSpec.describe "/preflights", type: :request do
 
   describe "POST /create" do
     before :all do
-      FileUtils.mkdir_p('tmp/test/uploads')
-      FileUtils.touch("tmp/test/uploads/MN-02 2.png")
-      FileUtils.touch("tmp/test/uploads/MN-02 3.png")
-      FileUtils.touch("tmp/test/uploads/MN-02 4.png")
+      FileUtils.mkdir_p('tmp/test/uploads/ftp')
+      FileUtils.touch("tmp/test/uploads/ftp/MN-02 2.png")
+      FileUtils.touch("tmp/test/uploads/ftp/MN-02 3.png")
+      FileUtils.touch("tmp/test/uploads/ftp/MN-02 4.png")
     end
     let(:valid_attributes) { { user: admin, manifest: tempfile } }
     let(:tempfile) { fixture_file_upload('csv/fancy.csv') }


### PR DESCRIPTION
Looks for FTP uploads under the uploads directory.
This change is a short-term fix until we can implement a more
consistent data directory heirarcy.

**BACKSTORY**
On the server we have different directories for import files and ftp
uploads:
FTP: /opt/data/client/upload
Import Files: /opt/data/uploads

As a short term fix, we've symlinked ftp upload under import files
```
ln -s /opt/data/client/upload /opt/data/uploads/ftp
```

This change updates application paths to be able to find the new
ftp symlink.