### PR TITLE
Fix for flapping CSV Import test

### DIFF
--- a/spec/lib/tenejo/csv_importer_spec.rb
+++ b/spec/lib/tenejo/csv_importer_spec.rb
@@ -228,6 +228,18 @@ RSpec.describe Tenejo::CsvImporter do
           expect(work.date_modified.in_time_zone).to be_within(1.minute).of Time.current
         end
       end
+
+      context 'with thumbnails' do
+        let(:csv) { fixture_file_upload("./spec/fixtures/csv/empty.csv") }
+        it 'log an error when missing' do
+          csv_import = described_class.new(import_job)
+          node = Tenejo::PFWork.new({ primary_identifier: 'ImNotHere' }, -1, nil, nil)
+
+          allow(Rails.logger).to receive(:error)
+          csv_import.ensure_thumbnails(node)
+          expect(Rails.logger).to have_received(:error).with(/ImNotHere/)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
We are experiencing periodic test failures
>Tenejo::CsvImporter calls modules - FLAKY
>spec.lib.tenejo.csv_importer_spec
>spec/lib/tenejo/csv_importer_spec.rb

```
Failure/Error: return if work.id && work&.thumbnail_id && work&.representative_id

NoMethodError:
  undefined method `id' for nil:NilClass
./app/lib/tenejo/csv_importer.rb:57:in `ensure_thumbnails'
```

Since that section of code shouldn't be called without a valid work, add a check
and log an error and return instead of raising an unhandled error.