### PR TITLE
User list on User Collections and Admin sets in dropdown

### DIFF
--- a/app/views/hyrax/admin/admin_sets/_form_participants.html.erb
+++ b/app/views/hyrax/admin/admin_sets/_form_participants.html.erb
@@ -45,8 +45,10 @@
                 <div class="form-group">
                   <label><%= t('.add_user') %></label>
                   <%= builder.hidden_field :agent_type %>
-                  <%= builder.text_field :agent_id,
-                                            placeholder: "Search for a user..." %>
+                  <%= builder.select :agent_id,
+                                    user_options,
+                                    { prompt: "Please select a user..."}, 
+                                    class: 'form-control' %>
                 </div>
                 <div class="form-group">
                   <label>can</label>

--- a/app/views/hyrax/dashboard/collections/_form_share.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form_share.html.erb
@@ -55,8 +55,10 @@
                 <div class="form-group">
                   <label><%= t('.add_user') %>:</label>
                   <%= builder.hidden_field :agent_type %>
-                  <%= builder.text_field :agent_id,
-                                        placeholder: t('.search_for_a_user') %>
+                  <%= builder.select :agent_id,
+                  user_options,
+                                        {prompt: t('.search_for_a_user')},
+                                        class: 'form-control' %>
                 </div>
                 <div class="form-group">
                   <label>can</label>


### PR DESCRIPTION
Previously adding users used a typeahead, specifically select2. This newer version uses a dropdown/select to add them to the collections, user or admin sets