### PR TITLE
Enable support for transcoding videos for playback

### DIFF
--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -67,7 +67,7 @@ Hyrax.config do |config|
   # config.persistent_hostpath = 'http://localhost/files/'
 
   # If you have ffmpeg installed and want to transcode audio and video set to true
-  # config.enable_ffmpeg = false
+  config.enable_ffmpeg = true
 
   # Hyrax uses NOIDs for files and collections instead of Fedora UUIDs
   # where NOID = 10-character string and UUID = 32-character string w/ hyphens


### PR DESCRIPTION
The default setting here was causing the derivative processor to
return without handling videos.
https://github.com/samvera/hyrax/blob/v3.1.0/app/jobs/create_derivatives_job.rb#L9