### PR TITLE
Assign noids to files without identifier in CSV

### DIFF
--- a/app/lib/tenejo/pf_object.rb
+++ b/app/lib/tenejo/pf_object.rb
@@ -91,7 +91,7 @@ module Tenejo
       index = 1
       packed = row[:files].include?("|~|")
       base_id = row[:identifier]
-      base_id = row[:identifier] = '~tbd~' if base_id.blank?
+      base_id = row[:identifier] = FileSet.new.assign_id if base_id.blank?
       files = row[:files].split("|~|").map do |f|
         cp[:files] = f
         cp[:identifier] = "#{base_id}.#{index}" if packed

--- a/spec/lib/tenejo/preflight_spec.rb
+++ b/spec/lib/tenejo/preflight_spec.rb
@@ -218,13 +218,15 @@ RSpec.describe Tenejo::Preflight do
       end
     end
     context "automatically when absent" do
+      let(:a_noid_pattern) { /^[a-z0-9]{9}/ }
       example "for single files" do
         jack_of_diamonds = diamonds.files[2]
-        expect(jack_of_diamonds.identifier).to eq ['~tbd~']
+        expect(jack_of_diamonds.identifier.first).to match a_noid_pattern
       end
       example "for packed files" do
         queen_of_diamonds_back = diamonds.files[4]
-        expect(queen_of_diamonds_back.identifier).to eq ['~tbd~.2']
+        expect(queen_of_diamonds_back.identifier.first).to match a_noid_pattern
+        expect(queen_of_diamonds_back.identifier.first).to match(/\.2$/) # i.e. end in '.2'
       end
       example "for files packed in files" do
         ace_of_hearts = hearts.children[0].files[0]


### PR DESCRIPTION
When a CSV does not specifiy an explicit identifier for a 'File'
row, assign a NOID (Nice Opaque IDentifier) as the identifier for
that file.

If the CSV provides and identifier, use the provided identifier.
NOTE: the system will still generate a NOID and use that for internal
references to the object.