### PR TITLE
Generate predicatable Identifiers for files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    samvera: samvera/circleci-orb@dev:8975953
+    samvera: samvera/circleci-orb@1.0.3
     browser-tools: circleci/browser-tools@1.2.4
 jobs:
     build:

--- a/app/lib/tenejo/pf_object.rb
+++ b/app/lib/tenejo/pf_object.rb
@@ -91,7 +91,7 @@ module Tenejo
       index = 1
       packed = row[:files].include?("|~|")
       base_id = row[:identifier]
-      base_id = row[:identifier] = FileSet.new.assign_id if base_id.blank?
+      base_id = row[:identifier] = row[:parent] + "//L#{lineno}" if base_id.blank?
       files = row[:files].split("|~|").map do |f|
         cp[:files] = f
         cp[:identifier] = "#{base_id}.#{index}" if packed

--- a/spec/lib/tenejo/preflight_spec.rb
+++ b/spec/lib/tenejo/preflight_spec.rb
@@ -218,15 +218,13 @@ RSpec.describe Tenejo::Preflight do
       end
     end
     context "automatically when absent" do
-      let(:a_noid_pattern) { /^[a-z0-9]{9}/ }
       example "for single files" do
         jack_of_diamonds = diamonds.files[2]
-        expect(jack_of_diamonds.identifier.first).to match a_noid_pattern
+        expect(jack_of_diamonds.identifier).to eq ["CARDS-0001-D//L10"]
       end
       example "for packed files" do
         queen_of_diamonds_back = diamonds.files[4]
-        expect(queen_of_diamonds_back.identifier.first).to match a_noid_pattern
-        expect(queen_of_diamonds_back.identifier.first).to match(/\.2$/) # i.e. end in '.2'
+        expect(queen_of_diamonds_back.identifier).to eq ["CARDS-0001-D//L11.2"]
       end
       example "for files packed in files" do
         ace_of_hearts = hearts.children[0].files[0]


### PR DESCRIPTION
Using NOIDs does not allow us to predict the identifier for a file
across runs unless was persist the assigned value somewhere; then
we'd have to check to see if an identifier had already been assigned
for a file in a parent in a job if we want to be able to match.

Using identifiers based on the position in the CSV allows us to
unambigously and consistently predict the identifier for a given file
in a given CSV.