### PR TITLE
Update warning message for missing parent works and collections

### DIFF
--- a/app/lib/tenejo/graph.rb
+++ b/app/lib/tenejo/graph.rb
@@ -64,13 +64,24 @@ class Tenejo::Graph
       if idx.key?(f.parent)
         idx[f.parent].children << f
       elsif f.parent.present?
-        @warnings << %/Could not find parent work or collection "#{f.parent}" for work or collection "#{f.identifier.first}" on line #{f.lineno}/
+        @warnings << %/Could not find parent "#{f.parent}" on line #{f.lineno}; #{simple_class(f)} "#{f.identifier.first}" will be created without a parent if you continue./
         @root.children << f
       else
         @root.children << f
       end
     end
     self
+  end
+
+  def simple_class(pf_obj)
+    case pf_obj
+    when Tenejo::PFWork
+      'work'
+    when Tenejo::PFCollection
+      'collection'
+    else
+      'unexpected class #{pf_obj.class}'
+    end
   end
 
   def index(c, key: :identifier)

--- a/spec/lib/tenejo/csv_importer_spec.rb
+++ b/spec/lib/tenejo/csv_importer_spec.rb
@@ -26,16 +26,17 @@ RSpec.describe Tenejo::CsvImporter do
     let(:csv) { fixture_file_upload("./spec/fixtures/csv/fancy.csv") }
     # rubocop:disable RSpec/MessageSpies
     it "returns warnings" do
-      allow(File).to receive(:exist?).and_return(true)
+      allow(File).to receive(:exist?).and_call_original
+      allow(File).to receive(:exist?).with(/png/).and_return(true)
       csv_import = described_class.new(import_job)
       expect(csv_import.preflight_errors).to eq []
       expect(csv_import.invalid_rows).to eq []
       expect(csv_import.preflight_warnings)
         .to contain_exactly(
               'The column "deduplication_key" is unknown, and will be ignored',
-              'Could not find parent work or collection "NONEXISTENT" for work or collection "NONACOLLECTION" on line 3',
+              'Could not find parent "NONEXISTENT" on line 3; collection "NONACOLLECTION" will be created without a parent if you continue.',
               'Could not find parent work "WHUT?" for file "MN-02 2.png" on line 6 - the file will be ignored',
-              'Could not find parent work or collection "NONA" for work or collection "MPC009" on line 10'
+              'Could not find parent "NONA" on line 10; work "MPC009" will be created without a parent if you continue.'
             )
     end
   end

--- a/spec/lib/tenejo/preflight_spec.rb
+++ b/spec/lib/tenejo/preflight_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe Tenejo::Preflight do
       expect(graph.works[1].children.map(&:identifier)).to eq [["MPC008"]]
     end
     it "warns about disconnected  works" do
-      expect(graph.warnings).to include "Could not find parent work or collection \"NONA\" for work or collection \"MPC009\" on line 10"
+      expect(graph.warnings).to include "Could not find parent \"NONA\" on line 10; work \"MPC009\" will be created without a parent if you continue."
     end
     it "connects works and collections with parents" do
       expect(graph.collections.size).to eq 2
@@ -116,7 +116,7 @@ RSpec.describe Tenejo::Preflight do
       expect(graph.collections.last.children.map(&:identifier)).to be_empty
     end
     it "warns when work has no parent" do
-      expect(graph.warnings).to include "Could not find parent work or collection \"NONEXISTENT\" for work or collection \"NONACOLLECTION\" on line 3"
+      expect(graph.warnings).to include "Could not find parent \"NONEXISTENT\" on line 3; collection \"NONACOLLECTION\" will be created without a parent if you continue."
     end
     it "warns files without parent in sheet" do
       expect(graph.warnings).to include "Could not find parent work \"WHUT?\" for file \"MN-02 2.png\" on line 6 - the file will be ignored"

--- a/spec/requests/preflight_request_spec.rb
+++ b/spec/requests/preflight_request_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "/preflights", type: :request do
       get preflight_path Job.last
       expect(response).to render_template('preflights/show')
       expect(response.body).to match(/preflight-warnings/)
-      expect(response.body).to match(/Could not find parent work or collection &quot;NONEXISTENT&quot;/)
+      expect(response.body).to match(/Could not find parent &quot;NONEXISTENT&quot;/)
     end
   end
 


### PR DESCRIPTION
This will change the preflight warning text from
>Could not find parent collection or work "YYYY" for collection or work "XXXX" on line N

To
>Could not find parent "YYYY" on line N; collection "XXXX" will be created without a parent if you continue.