### PR TITLE
Update CI bundler version to match Gemfile.lock version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
                 default: 2.7.4
             bundler_version:
                 type: string
-                default: 2.2.33
+                default: 2.3.14
         environment:
           DATABASE_URL: postgresql://postgres@127.0.0.1/circle_test
           DATABASE_NAME: circle_test
@@ -109,7 +109,7 @@ jobs:
                 default: 2.7.4
             bundler_version:
                 type: string
-                default: 2.2.29
+                default: 2.3.14
         docker:
             - image: cimg/ruby:2.7.4-browsers
         working_directory: ~/project


### PR DESCRIPTION
This change addresses the following warning during CI runs:
>Warning: the running version of Bundler (2.2.33) is older than the version that created the lockfile (2.3.14). We suggest you to upgrade to the version that created the lockfile by running `gem install bundler:2.3.14`.