### PR TITLE
Fix Sipity errors when re-ingesting a CSV

### DIFF
--- a/app/lib/tenejo/csv_importer.rb
+++ b/app/lib/tenejo/csv_importer.rb
@@ -132,12 +132,6 @@ module Tenejo
       update_work_attributes(work, pfwork)
       create_or_update_files(work, pfwork)
       save_work(work)
-      check_workflow(work)
-    end
-
-    # Sets the workflow on newly deposited works
-    def check_workflow(work)
-      Hyrax::Workflow::WorkflowFactory.create(work, {}, @job.user)
     end
 
     # Finds or creates a work by its user supplied identifier
@@ -227,7 +221,10 @@ module Tenejo
     def save_work(work)
       return unless work
       begin
-        work.save! # do we need to go through the actor stack?
+        newly_created = !work.persisted?
+        work.save!
+        # Add Sipity workflow to newly created works
+        Hyrax::Workflow::WorkflowFactory.create(work, {}, @job.user) if newly_created
         # update job status table - work creation successful
       rescue
         # update job status table - work creation failed - save error to table

--- a/spec/lib/tenejo/csv_importer_spec.rb
+++ b/spec/lib/tenejo/csv_importer_spec.rb
@@ -185,13 +185,11 @@ RSpec.describe Tenejo::CsvImporter do
 
       it "uses the existing work instead of creating a new one" do
         csv_import = described_class.new(import_job)
-        allow(csv_import).to receive(:check_workflow)
         expect { csv_import.create_or_update_work(pf_work) }.not_to change { Work.where(primary_identifier_ssi: 'WORK-0002').count }
       end
 
       it "sets administrative data", :aggregate_failures do
         csv_import = described_class.new(import_job)
-        allow(csv_import).to receive(:check_workflow)
         csv_import.create_or_update_work(pf_work)
         work = Work.where(primary_identifier_ssi: 'WORK-0002').last
         expect(work.depositor).not_to be_nil
@@ -217,7 +215,6 @@ RSpec.describe Tenejo::CsvImporter do
 
         it "updates all of them", :aggregate_failures do
           csv_import = described_class.new(import_job)
-          allow(csv_import).to receive(:check_workflow)
           csv_import.create_or_update_work(pf_work)
           work = Work.where(primary_identifier_ssi: 'WORK-0002').last
 


### PR DESCRIPTION
When we re-ingest or update a work via CSV import, it has been
throwing the following error
```
Jun 21 10:32:20 tenejo sidekiq[3688004]: 2022-06-21T15:32:20.449Z pid=3688004 tid=1zd60 class=BatchImportJob jid=18f52af10216e2cfa3ebc46b ERROR: Error performing BatchImp
ortJob (Job ID: 937b80c5-3fe0-4d6a-bf76-b27381652fef) from Sidekiq(default) in 163411.54ms: ActiveRecord::RecordNotUnique (PG::UniqueViolation: ERROR:  duplicate key valu
e violates unique constraint "sipity_entities_proxy_for_global_id"
Jun 21 10:32:20 tenejo sidekiq[3688004]: DETAIL:  Key (proxy_for_global_id)=(gid://tenejo/Work/rv042t36q) already exists.
Jun 21 10:32:20 tenejo sidekiq[3688004]: : INSERT INTO "sipity_entities" ("proxy_for_global_id", "workflow_id", "created_at", "updated_at") VALUES ($1, $2, $3, $4) RETURNING "id"):
```

Sipity raises an exception during the create entity request if
a record already exists for the corresponding work in the entity
table.  Sipity does not provide a find_or_create equivalent method.

This code moves the sipity check and only attempts to create the
workflow (Sipity) entity for new works that have not been previously
persisted (saved).  If the work has already been persisted, the
importer assumes that a workflow proxy (Sipity Entity) has already
been created.