### PR TITLE
Add additional status to Import Jobs

### DIFF
--- a/spec/lib/tenejo/csv_importer_spec.rb
+++ b/spec/lib/tenejo/csv_importer_spec.rb
@@ -19,6 +19,9 @@ RSpec.describe Tenejo::CsvImporter do
       expect(csv_import).not_to receive(:create_or_update_collection)
       expect(csv_import).not_to receive(:create_or_update_work)
       csv_import.import
+
+      expect(import_job.status).to eq 'errored'
+      expect(import_job.completed_at).to be_within(1.second).of Time.current
     end
   end
 
@@ -29,6 +32,7 @@ RSpec.describe Tenejo::CsvImporter do
       allow(File).to receive(:exist?).and_call_original
       allow(File).to receive(:exist?).with(/png/).and_return(true)
       csv_import = described_class.new(import_job)
+      expect(import_job.status).to eq 'submitted'
       expect(csv_import.preflight_errors).to eq []
       expect(csv_import.invalid_rows).to eq []
       expect(csv_import.preflight_warnings)
@@ -50,6 +54,12 @@ RSpec.describe Tenejo::CsvImporter do
 
     expect(csv_import).to have_received(:create_or_update_collection).exactly(3).times
     expect(csv_import).to have_received(:create_or_update_work).exactly(9).times
+
+    expect(import_job.status).to eq 'completed'
+    expect(import_job.collections).to eq 3
+    expect(import_job.works).to eq 9
+    expect(import_job.files).to eq 17
+    expect(import_job.completed_at).to be_within(1.second).of Time.current
   end
 
   context '.create_or_update_collection' do


### PR DESCRIPTION
Adds the following statuses to Import Jobs
* errored: if an import job gets submitted from a preflight with fatal errors
* submitted: import job has been put in queue but no workers avaialbe yet
* in_progress: background workers are processing the CSV import
* completed: the import has been completed

NOTE: the errored state is unlikely to appear in production since a
user cannot submit a preflight with fatal errors for import.  The
test suite does, however, allow for this case, so we add appropriate
messaging.

<img width="784" alt="image" src="https://user-images.githubusercontent.com/3064318/184931756-18532f95-b150-455c-b90e-5812477d6d22.png">

<img width="807" alt="image" src="https://user-images.githubusercontent.com/3064318/184932166-4cdf738f-356b-405e-a5f7-ad1e91ee7eac.png">
