### PR TITLE
Fix duplicate email error in create_user task

### DIFF
--- a/lib/tasks/tenejo.rake
+++ b/lib/tasks/tenejo.rake
@@ -4,15 +4,11 @@ CHARS = ('0'..'9').to_a + ('A'..'Z').to_a + ('a'..'z').to_a
 namespace :tenejo do
   desc 'Create  user'
   task :create_user, [:email] => :environment do |_t, args|
-    r = Role.find_or_create_by(name: 'admin') do
-      Role.create!(name: 'admin')
-    end
+    r = Role.find_or_create_by(name: 'admin')
     pw = random_password
     email = args[:email] || 'admin@example.com'
-    User.where(email: email).first&.destroy
-    u = User.create!(email: email, password: pw, password_confirmation: pw)
-    u.roles << r
-    u.save!
+    User.where(email: email).first&.delete
+    User.create!(email: email, password: pw, roles: [r])
     puts "Password: #{pw}"
   end
   def random_password(length = 16)


### PR DESCRIPTION
ISSUE
Running the create_user task was giving an error:
```
ActiveRecord::RecordInvalid: Validation failed: Email has already been taken
/Users/mark/_no_backup_/Projects/tenejo/lib/tasks/tenejo.rake:13
```

ANALYSIS
The issue appears to be happening becuase we overrode the User#destroy
method to deactive rather than delete a user.

CHANGE
* Call #delete instead of #destroy to remove previous accounts
* Set the admin role in the User#create call instead of having to save again
* Omit redundant password confirmation (only required for form base p/w changes)