### PR TITLE
Fix bug adding files to works in importer

### DIFF
--- a/app/lib/tenejo/csv_importer.rb
+++ b/app/lib/tenejo/csv_importer.rb
@@ -228,7 +228,7 @@ module Tenejo
       #       Hyrax.publisher.publish('file.set.attached', file_set: file_set, user: user)
       #       Hyrax.publisher.publish('object.metadata.updated', object: file_set, user: user)
       #     end"
-      work.ordered_members = file_sets
+      work.ordered_members.concat(file_sets)
       work.thumbnail ||= file_sets.first
       work.representative ||= file_sets.first
     end

--- a/spec/fixtures/csv/file_test.csv
+++ b/spec/fixtures/csv/file_test.csv
@@ -2,4 +2,4 @@ Identifier,Object Type,Parent,Title,Description,Creator,Rights Statement,Visibil
 CARDS-0001-J,Work,CARDS-JJ,Jokers,Work with mixed packing of files,T. C. Oyun Kagitlari Monopolu,Copyright Not Evaluated,Public,jokers/Joker1-Recto.tiff|~|jokers/Joker1-Verso.tiff
 ,File,CARDS-0001-J, ,,,,private,jokers/Joker2-Recto.tiff|~|jokers/Joker2-Verso.tiff
 CARDS-JJ,Work,,Meta Jokers,Work with child works but no direct files,T. C. Oyun Kagitlari Monopolu,Copyright Not Evaluated,Public,
-CARDS-AH,Work,,Ace of Hearts,No Jokers here,T. C. Oyun Kagitlari Monopolu,Copyright Not Evaluated,Public,jokers/Joker2-Recto.tiff|~|jokers/Joker2-Verso.tiff
+CARDS-AH,Work,,Ace of Hearts,No Jokers here,T. C. Oyun Kagitlari Monopolu,Copyright Not Evaluated,Public,jokers/Joker2-Recto.tiff

--- a/spec/lib/tenejo/csv_importer_file_spec.rb
+++ b/spec/lib/tenejo/csv_importer_file_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Tenejo::CsvImporter do
     ace_of_hearts = Work.where(primary_identifier_ssi: 'CARDS-AH').last
     expect(ace_of_hearts.title).to eq ['Ace of Hearts']
     expect(ace_of_hearts.description).to eq ['No Jokers here'] # changed from 'A pre-existing work'
-    expect(ace_of_hearts.file_sets.count).to eq 3 # added 2 file_sets during import
+    expect(ace_of_hearts.ordered_members.to_a.size).to eq 2 # started with 1 and added 1 during import
     expect(ace_of_hearts.modified_date).not_to eq ace_of_hearts.create_date # modified_date should have been modified by the importer
   end
 end


### PR DESCRIPTION
Adding a list of filesets to a work's `ordered_members` replaces
ordered members, BUT adds those filesets to `file_sets`.

Concatenating rather than assigning filesets ensures that
`ordered_members` and `file_sets` are updated in parallel
and retain the same members.