### PR TITLE
Add a CSV export service

### DIFF
--- a/app/lib/tenejo/csv_exporter.rb
+++ b/app/lib/tenejo/csv_exporter.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+require 'tenejo/pf_object'
+
+module Tenejo
+  class CsvExporter
+    EXPORT_HEADERS = ([:identifier, :error, :class, :title] + Tenejo::CsvImporter.collection_attributes_to_copy.keys + Tenejo::CsvImporter.work_attributes_to_copy.keys).uniq
+
+    def initialize(export_job)
+      @export = export_job
+    end
+
+    def run
+      Tempfile.create(['export-', '.csv']) do |csv|
+        csv << EXPORT_HEADERS.join(',') + "\n"
+        csv << ",No identifiers provided,\n" if @export.identifiers.empty?
+        @export.identifiers.each do |id|
+          csv << serialize(id)
+        end
+        csv.rewind
+        @export.manifest.attach(io: csv, filename: File.basename(csv.path), content_type: 'text/csv')
+      end
+    end
+
+    private
+
+    def serialize(id)
+      obj = ActiveFedora::Base.where(primary_identifier_ssi: id).last
+      return "#{id},No match for identifier\n" unless obj
+      row = []
+      EXPORT_HEADERS.each do |attr|
+        val = obj.try(attr)
+        if val.is_a?(ActiveTriples::Relation)
+          val = (val.to_a.join('|~|') if val.present?)
+        end
+        val = val.gsub('"', '""') if val.respond_to?(:gsub) # escape double quotes for CSV
+        val = %("#{val}") if val.present? # wrap non-empty values in double quotes for CSV
+        row << val
+      end
+      row[0] = id
+      row.join(',') + "\n"
+    end
+  end
+end

--- a/app/lib/tenejo/csv_importer.rb
+++ b/app/lib/tenejo/csv_importer.rb
@@ -146,7 +146,7 @@ module Tenejo
 
     def update_collection_attributes(collection, pfcollection)
       return unless collection
-      collection_attributes_to_copy.each { |source, dest| collection.send(dest, pfcollection.send(source)) }
+      Tenejo::CsvImporter.collection_attributes_to_copy.each { |source, dest| collection.send(dest, pfcollection.send(source)) }
 
       collection.primary_identifier = pfcollection.identifier.first
 
@@ -201,7 +201,7 @@ module Tenejo
 
     def update_work_attributes(work, pfwork)
       return unless work
-      work_attributes_to_copy.each { |source, dest| work.send(dest, pfwork.send(source)) }
+      Tenejo::CsvImporter.work_attributes_to_copy.each { |source, dest| work.send(dest, pfwork.send(source)) }
       set_work_parent(work, pfwork)
       update_timestamp(work)
       work.admin_set ||= admin_set_for_work
@@ -298,23 +298,23 @@ module Tenejo
       @rights_statements ||= Hyrax.config.rights_statement_service_class.new
     end
 
-    def collection_attributes_to_copy
+    def self.collection_attributes_to_copy
       @collection_attributes_to_copy ||=
         ((Collection.terms & Tenejo::PFCollection::ALL_FIELDS) - collection_fields_to_exclude + [:visibility]
         ).map { |key| [key, "#{key}=".to_sym] }.to_h
     end
 
-    def collection_fields_to_exclude
+    def self.collection_fields_to_exclude
       [:collection_type_gid, :depositor, :has_model, :date_uploaded, :create_date, :modified_date, :head, :tail]
     end
 
-    def work_attributes_to_copy
+    def self.work_attributes_to_copy
       @work_attributes_to_copy ||=
         ((Work.terms & Tenejo::PFWork::ALL_FIELDS) - work_fields_to_exclude + [:visibility]
         ).map { |key| [key, "#{key}=".to_sym] }.to_h
     end
 
-    def work_fields_to_exclude
+    def self.work_fields_to_exclude
       [:depositor, :has_model, :date_uploaded, :create_date, :modified_date, :head, :tail]
     end
   end

--- a/spec/lib/tenejo/csv_exporter_spec.rb
+++ b/spec/lib/tenejo/csv_exporter_spec.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+require 'csv'
+require 'rails_helper'
+
+RSpec.describe Tenejo::CsvExporter do
+  let(:job_owner) { FactoryBot.create(:user) }
+  let(:export) { Export.create(user: job_owner) }
+
+  after do
+    # active storage files are not deleted automatically
+    export.manifest.purge
+  end
+
+  context 'CSV' do
+    let(:col001) {
+      Collection.new(title: ['Test collection'], primary_identifier: 'COL001',
+                     collection_type_gid: Hyrax::CollectionType.find_or_create_default_collection_type.gid)
+    }
+
+    let(:work001) { Work.new(title: ['Test work'], primary_identifier: 'WRK001') }
+
+    it 'gets attached on export', :aggregate_failures do
+      expect(export.manifest.attached?).to be false
+      described_class.new(export).run
+      expect(export.manifest.attached?).to be true
+    end
+
+    it 'includes error message if no identifiers were provided' do
+      described_class.new(export).run
+      rows = CSV.parse(export.manifest.download, headers: true)
+      expect(rows.first['error']).to eq 'No identifiers provided'
+    end
+
+    it 'includes row-level errors' do
+      export.identifiers = ['invalid_id']
+      export.save
+      described_class.new(export).run
+      rows = CSV.parse(export.manifest.download, headers: true)
+      expect(rows.first['identifier']).to eq 'invalid_id'
+      expect(rows.first['error']).to eq 'No match for identifier'
+    end
+
+    it 'includes metadata for collections and works', :aggregate_failures do
+      allow(ActiveFedora::Base).to receive(:where).and_return([col001], [work001])
+
+      export.identifiers = ['COL001', 'WRK001']
+      export.save
+      described_class.new(export).run
+      rows = CSV.parse(export.manifest.download, headers: true)
+
+      # Collection COL001
+      expect(rows[0]['identifier']).to eq 'COL001'
+      expect(rows[0]['error']).to be_nil
+      expect(rows[0]['title']).to include 'Test collection'
+      expect(rows[0]['class']).to eq "Collection"
+
+      # Work WRK001
+      expect(rows[1]['identifier']).to eq 'WRK001'
+      expect(rows[1]['error']).to be_nil
+      expect(rows[1]['title']).to include 'Test work'
+      expect(rows[1]['class']).to eq "Work"
+    end
+  end
+
+  context "#serialize" do
+    let(:max_work) {
+      Work.new(
+        title: ['Work with all the fields'],
+        primary_identifier: 'MAX-WORK',
+        identifier: ['DOI:xxxxxxx', 'http://hdl.handle.net/ooooo/iiiiiiiii'],
+        alternative_title: ['Alle Felder', 'सर्वाणि क्षेत्राणि'],
+        resource_type: ["Image"],
+        creator: ["Anon., 16th Century"],
+        contributor: ["c2"],
+        description: ["Here's some mixed \"s & quotes'"],
+        abstract: ["impressionism"],
+        keyword: ["none", "one", "some"],
+        license: ["All rights reserved"],
+        rights_notes: ["use freely"],
+        rights_statement: ["No Copyright - United States"],
+        publisher: ["DCE"],
+        date_created: ["2021-12-06"],
+        subject: ["tbd"],
+        language: ["english"],
+        related_url: ["/also/#"],
+        bibliographic_citation: ["see also"],
+        source: ["mhb"],
+        # single valued
+        depositor: "admin@example.com",
+        date_uploaded: "2021-01-01 00:00:01",
+        date_modified: nil
+      )
+    }
+
+    let(:serialized) { described_class.new(user: job_owner).send(:serialize, 'MAX-WORK') }
+
+    before do
+      allow(ActiveFedora::Base).to receive(:where).and_return([max_work])
+    end
+
+    it "returns a string" do
+      expect(serialized).to be_a String
+    end
+
+    it "handles all the fields" do
+      # Just check for one value deep in the array
+      # Otherwise we need to check the whole exact string and the test becomes fragile
+      expect(serialized).to include 'use freely'
+    end
+
+    it "handles multi-valued fields" do
+      # ActiveTriples does not guarantee order, so we have to test for either order
+      match1 = serialized.match?('सर्वाणि क्षेत्राणि\|\~\|Alle Felder')
+      match2 = serialized.match?('Alle Felder\|\~\|सर्वाणि क्षेत्राणि')
+      expect(match1 || match2).to be true
+    end
+
+    it "handles embedded quotes" do
+      expect(serialized).to include %q(Here's some mixed ""s & quotes')
+    end
+
+    it "handles embedded commas" do
+      expect(serialized).to include 'Anon., 16th Century'
+    end
+  end
+end


### PR DESCRIPTION
The service accepts the an Export job that includes one or
more identifiers for export.  The metadata for corresponding
collections and works is serialized to a CSV.  The CSV is
saved as an attachment to the Export job and can then be
downloaded at a future point.

NOTE: this change does not include the UI components which will
be required for users to access the service.