### PR TITLE
Refactor job status helper

### DIFF
--- a/app/assets/stylesheets/jobs.scss
+++ b/app/assets/stylesheets/jobs.scss
@@ -112,21 +112,31 @@
 .badge {
   padding: 0.7rem 1.2rem;
 
-  &.bg-success {
-    background-color: rgba(47, 179, 68, 0.1) !important;
+  &.status-submitted {
+    background-color: lightblue;
+    color: darkblue;
+  }
+  &.status-completed {
+    background-color: rgba(47, 179, 68, 0.1);
     color: #2fb344;
   }
-  &.bg-danger {
-    background-color: rgba(211, 58, 53, 0.1) !important;
+  &.status-errored {
+    background-color: rgba(211, 58, 53, 0.1);
     color: #d33a35;
   }
-  .bg-warning {
-    background-color: rgba(254, 216, 0, 0.1) !important;
+  &.status-in-progress {
+    background-color: rgba(254, 216, 0, 0.1);
     color: #927c00;
   }
-  &.bg-info {
-    color: #000 !important;
+  &.status-unknown {
     background-color: rgba(217, 237, 247, 0.5) !important;
+    color: black;
+  }
+
+  &.status-unrecognized {
+    ::before { content: '⚠️' };
+    background-color: lightgoldenrodyellow;
+    color: black;
   }
 }
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -61,20 +61,23 @@ module ApplicationHelper
   end
 
   def status_span_generator(status)
-    case status
-    when 'submitted'
-      tag(:span, status.titleize, class: 'job-status badge rounded-pill bg-default')
-    when 'errored'
-      tag(:span, status.titleize, class: 'job-status badge rounded-pill bg-danger')
-    when 'completed'
-      tag(:span, status.titleize, class: 'job-status badge rounded-pill bg-success')
-    when 'in_progress'
-      tag(:span, status.titleize, class: 'job-status badge rounded-pill bg-warning')
+    status_text = status.to_s.titleize
+    case status_text
+    when 'Submitted'
+      status_classes = 'status-submitted'
+    when 'Errored'
+      status_classes = 'status-errored'
+    when 'Completed'
+      status_classes = 'status-completed'
+    when 'In Progress'
+      status_classes = 'status-in-progress'
     when 'Unknown'
-      tag(:span, status.titleize, class: 'job-status badge rounded-pill')
+      status_classes = 'status-unknown'
     else
-      tag(:span, '📖 Banana', class: 'job-status badge rounded-pill bg-info')
+      status_classes = 'status-unrecognized'
+      status_text = 'Unrecognized Status'
     end
+    tag.span(status_text, class: 'job-status badge rounded-pill ' + status_classes)
   end
 
   def collection_permission_template_form_for(form:)

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -6,4 +6,18 @@ describe ApplicationHelper do
     expect(helper.random_image).not_to be_nil
     expect(helper.random_image).to match(/unsplash\/.*\.jpg/)
   end
+
+  context "#status_span_generator" do
+    example "for known statuses" do
+      expect(helper.status_span_generator('submitted')).to include "Submitted"
+    end
+
+    example "for unrecognized statuses" do
+      expect(helper.status_span_generator("it's complicated")).to include "Unrecognized"
+    end
+
+    example "accepts symbols" do
+      expect(helper.status_span_generator(:in_progress)).to include "In Progress"
+    end
+  end
 end

--- a/spec/views/imports/show.html.erb_spec.rb
+++ b/spec/views/imports/show.html.erb_spec.rb
@@ -16,14 +16,14 @@ RSpec.describe "imports/show", type: :view do
       files: 17
     )
   }
-  let(:import_job) { Import.create!(user: admin, parent_job: preflight, graph: Tenejo::Preflight.process_csv(preflight.manifest.download)) }
+  let(:import_job) { Import.create!(user: admin, parent_job: preflight, graph: Tenejo::Preflight.process_csv(preflight.manifest.download), status: :submitted) }
 
   it "renders attributes", :aggregate_failures do
     @job = import_job
     @root = {}
     render
     expect(rendered).to have_selector('.jobs-user', text: admin)
-    expect(rendered).to have_selector('.jobs-status', text: 'Unknown')
+    expect(rendered).to have_selector('.job-status', text: 'Submitted')
     expect(rendered).to have_selector('.jobs-created_at', text: import_job.created_at)
     expect(rendered).to have_selector('.jobs-completed_at', text: '--')
     expect(rendered).to have_selector('.jobs-collections', text: 'N/A')


### PR DESCRIPTION
* Add basic tests for job status helper
* Update deprecated tag syntax
* Use dedicated status classes instead of overriding background classes
* Organize helper to highlight differences between statuses
* Update import show spec to reflect badge change