### PR TITLE
Fix circular dependency error in background import jobs

### DIFF
--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -6,6 +6,4 @@ class Job < ApplicationRecord
 
   has_many :child_jobs, class_name: 'Job', foreign_key: 'parent_job_id', dependent: :nullify
   belongs_to :parent_job, class_name: 'Job', optional: true
-
-  [Preflight, Import, Export] if Rails.env.development? # preload subclasses in development so STI doesn't break
 end


### PR DESCRIPTION
The issue is only happening in devlopment environments because of
dynamic code reloading issues. In production, all code it pre-loaded.
```
ActiveJob::DeserializationError: Error while trying to deserialize arguments: Circular dependency detected while autoloading constant Import
```