### PR TITLE
Ignore blank identifiers sent to the Export controller

### DIFF
--- a/app/controllers/exports_controller.rb
+++ b/app/controllers/exports_controller.rb
@@ -18,6 +18,7 @@ class ExportsController < JobsController
 
   def create
     @job = Export.new(job_params.merge({ user: current_user, status: :submitted }))
+    @job.identifiers.reject!(&:blank?)
     respond_to do |format|
       if @job.save
         BatchExportJob.perform_later(@job)

--- a/spec/requests/export_request_spec.rb
+++ b/spec/requests/export_request_spec.rb
@@ -49,5 +49,11 @@ RSpec.describe "/exports", type: :request do
       post exports_path, params: { export: { identifiers: [] } }
       expect(response).to redirect_to Export.last
     end
+
+    it "omits blank identifiers" do
+      # Check that we ignore empty strings, nil, and things that evaluate to either
+      post exports_path, params: { export: { identifiers: ["", nil, "DummyID", %q(), {}[:field]] } } # rubocop:disable Style/RedundantPercentQ
+      expect(Export.last.identifiers).to eq ['DummyID']
+    end
   end
 end


### PR DESCRIPTION
If a user manages to submit an export request with an empty
element in the identifier arrary (i.e. nil, or ''), we want to
disregard it since it can not match a valid identifier and
may return unexpected results.