### PR TITLE
Refactor exporter tests to decouple file IO from csv_generation

### DIFF
--- a/spec/models/batch_jobs/export_spec.rb
+++ b/spec/models/batch_jobs/export_spec.rb
@@ -46,8 +46,6 @@ RSpec.describe Export, type: :model do
       found_job = described_class.find(export.id)
       expect(found_job.manifest).to be_a_kind_of ActiveStorage::Attached::One
       expect(found_job.manifest.filename).to eq 'empty.csv'
-      # active storage files are not deleted automatically
-      found_job.manifest.purge
     end
   end
 end

--- a/spec/models/batch_jobs/preflight_spec.rb
+++ b/spec/models/batch_jobs/preflight_spec.rb
@@ -23,7 +23,5 @@ RSpec.describe Preflight, type: :model do
     found_job = described_class.find(job.id)
     expect(found_job.manifest).to be_a_kind_of ActiveStorage::Attached::One
     expect(found_job.manifest.filename).to eq 'empty.csv'
-    # active storage files are not deleted automatically
-    found_job.manifest.purge
   end
 end

--- a/spec/models/theme_spec.rb
+++ b/spec/models/theme_spec.rb
@@ -74,7 +74,5 @@ RSpec.describe Theme, type: :model do
     found_theme = described_class.find(theme.id)
     expect(found_theme.logo).to be_a_kind_of ActiveStorage::Attached::One
     expect(found_theme.logo.filename).to eq 'Noun Project Bank.png'
-    # active storage files are not deleted automatically
-    found_theme.logo.purge
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -55,6 +55,9 @@ RSpec.configure do |config|
   # Ensure a default Theme exists for all tests
   config.before(:suite) { Theme.where(id: 1).first_or_create! }
 
+  # Delete any ActiveStorage files created during test runs
+  config.after(:suite) { FileUtils.rm_rf(ActiveStorage::Blob.service.root) }
+
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
   config.include Devise::Test::ControllerHelpers, type: :controller


### PR DESCRIPTION
Having to save and read a file attachment everytime we want to test
the behavior of CSV generation adds a lot of overhead to tests.

This change separates generating the CSV output as an in memory string
from savinging it as an ActiveStorage attachment so we can test
each separately.

This change also adds an after-suite call to clean up all ActiveStorage
so we don't get leftover attachment files from tests.