### PR TITLE
Fix import status reporting for nested objects

### DIFF
--- a/app/lib/tenejo/csv_importer.rb
+++ b/app/lib/tenejo/csv_importer.rb
@@ -102,7 +102,7 @@ module Tenejo
       found = item.children.find { |x| x['identifier'] == child_id }
       if !found && !item.children.empty?
         item.children.each do |x|
-          found = search(typify(x), child_id)
+          found ||= search(typify(x), child_id)
         end
       end
       found

--- a/spec/lib/tenejo/csv_importer_nesting_spec.rb
+++ b/spec/lib/tenejo/csv_importer_nesting_spec.rb
@@ -53,6 +53,23 @@ RSpec.describe Tenejo::CsvImporter do
     expect(greatgrandchild.parent_works).to include grandchild
   end
 
+  it 'sets item-level import status', :aggregate_failures do
+    # TODO: figure out a more readable test
+    # There should probably be some clearer unit-level tests too.
+
+    job = @csv_import.instance_variable_get(:@job)
+    root_children = job.graph['root']['children']
+    root_children_status = root_children.map { |c| c['status'] }
+    expect(root_children_status).to eq ["complete", "complete", "complete"]
+
+    first_child = job.graph['root']['children'][2]['children'][0]['children'][0]['children'][0]['children'][0]
+    expect(first_child['title']).to eq ["Ace of Hearts"]
+    expect(first_child['status']).to eq "complete"
+
+    hearts_status = job.graph['root']['children'][2]['children'][0]['children'][0]['children'].map { |c| c['status'] }
+    expect(hearts_status).to eq ["complete", "complete", "complete", "complete", "complete"]
+  end
+
   it 'sets work-level visibility', :aggregate_failures do
     private_work = Work.where(primary_identifier_ssi: 'ORPH-0001').first
     institutional_work = Work.where(primary_identifier_ssi: 'ORPH-0002').first


### PR DESCRIPTION
**ISSUE**
The import status for nested collections and works was not updating to "complete" despite the objects being successfully created and the overall job being marked as completed.

**DIAGNOSIS**
If an object's parent had following siblings in the heirarchy, the search method would overwrite the the succesfully found object with `nil` when completing the search iteration on the previous ancestor level.

**FIX**
Only assign `found` on the initial match so that it is not overwritten by nil values returned from searching subsequent children at the same level.

![import_status](https://user-images.githubusercontent.com/3064318/189270337-0726ad2d-dda4-4da8-832d-8d2e9ad21d08.gif)
