### PR TITLE
Save the preflight analysis data when running a new preflight

### DIFF
--- a/app/controllers/preflights_controller.rb
+++ b/app/controllers/preflights_controller.rb
@@ -20,7 +20,7 @@ class PreflightsController < JobsController
 
   def create
     @job = Preflight.new(job_params.merge({ user: current_user }))
-    @graph = run_preflight(@job) if @job.validate
+    @job.graph = run_preflight(@job) if @job.validate
 
     respond_to do |format|
       if @job.save

--- a/spec/requests/preflight_request_spec.rb
+++ b/spec/requests/preflight_request_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe "/preflights", type: :request do
       it "sets the collections, works, and jobs count", :aggregate_failures do
         post preflights_path, params: { preflight: valid_attributes }
         created_job = assigns(:job)
-        expect(assigns(:graph)).not_to be_nil
+        expect(created_job.graph).not_to be_nil
         expect(created_job.status).to eq 'completed'
         expect(created_job.completed_at).to be_within(1.second).of Time.current
         expect(created_job.collections).to eq 2


### PR DESCRIPTION
Before we were able to persist the job graph as json, they were treated as ephemeral and regenerated every time they were needed.

Now that we can persist the graph, this change saves it when the preflight job is created.