### PR TITLE
Elimiate flash messages for new Preflight and Import jobs

### DIFF
--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -28,7 +28,7 @@ class ImportsController < JobsController
     respond_to do |format|
       if @job.save
         BatchImportJob.perform_later(@job)
-        format.html { redirect_to @job, notice: "Job was successfully created." }
+        format.html { redirect_to @job }
         format.json { render :show, status: :created, location: @job }
       end
     end

--- a/app/controllers/preflights_controller.rb
+++ b/app/controllers/preflights_controller.rb
@@ -24,7 +24,7 @@ class PreflightsController < JobsController
 
     respond_to do |format|
       if @job.save
-        format.html { redirect_to @job, notice: "Job was successfully created." }
+        format.html { redirect_to @job }
         format.json { render :show, status: :created, location: @job }
       else
         format.html { render :new, status: :unprocessable_entity }


### PR DESCRIPTION
Successfully showing the new Preflight or Import status page (i.e. show view) provides a clear indication the job was created.

This change removes the redundant flash message that clutters up the UI.

**BEFORE**
<img width="1170" alt="image" src="https://user-images.githubusercontent.com/3064318/189390923-ecd553d9-146b-4bde-987d-48b575e5085a.png">

**AFTER**
<img width="1170" alt="image" src="https://user-images.githubusercontent.com/3064318/189391124-cbbbd6a3-1b37-4f91-84d3-ec2cfa3e4c7e.png">
