### PR TITLE
Update Rights Statement validations to require exact match

### DIFF
--- a/app/lib/tenejo/pf_object.rb
+++ b/app/lib/tenejo/pf_object.rb
@@ -8,7 +8,7 @@ module Tenejo
       matched, unmatched = licenses.partition { |id| license_authority.find(id).present? }
       to_convert, invalid = unmatched.partition { |term| license_authority.search(term).present? }
       invalid.each do |license|
-        record.warnings[:license] << "License \'#{license}\' is not recognized and will be omitted"
+        record.warnings[:license] << "License '#{license}' is not recognized and will be omitted"
       end
       converted = to_convert.map { |term| license_authority.search(term).first['id'] }
       record.license = (matched + converted).uniq
@@ -26,7 +26,7 @@ module Tenejo
       return unless record.resource_type
       record.resource_type, invalid_names = record.resource_type.partition { |term| RESOURCE_TYPES.include?(term) }
       invalid_names.each do |term|
-        record.warnings[:resource_type] << "Resource Type \'#{term}\' is not recognized and will be omitted."
+        record.warnings[:resource_type] << "Resource Type '#{term}' is not recognized and will be omitted."
       end
     end
   end
@@ -35,10 +35,9 @@ module Tenejo
     def validate(record)
       rights_statements = Array.wrap(record.rights_statement)
       rights = rights_statements.first
-      matched = rights_statement_authority.find(rights)['id'] # matches when passed a valid id
-      matched ||= rights_statement_authority.search(rights).first&.fetch('id') # matches when passed a valid term
+      matched = rights_statement_authority.find { |r| r.key(rights) }
       if matched
-        record.rights_statement = [matched]
+        record.rights_statement = [matched[:id]]
       else
         record.warnings[:rights_statement] << main_warning(rights)
         record.rights_statement = ['https://rightsstatements.org/vocab/UND/1.0/']
@@ -48,7 +47,7 @@ module Tenejo
 
     def main_warning(rights)
       if rights.present?
-        "Rights Statement \'#{rights}\' is not recognized and will be set to 'Copyright Undetermined'"
+        "Rights Statement '#{rights}' is not recognized and will be set to 'Copyright Undetermined'"
       else
         "Rights Statement cannot be blank and will be set to 'Copyright Undetermined'"
       end
@@ -59,7 +58,7 @@ module Tenejo
     end
 
     def rights_statement_authority
-      @rights_statement_authority ||= Hyrax.config.rights_statement_service_class.new.authority
+      @rights_statement_authority ||= Hyrax.config.rights_statement_service_class.new.active_elements
     end
   end
 
@@ -158,7 +157,7 @@ module Tenejo
     validates_presence_of(*REQUIRED_FIELDS)
     validates_with Tenejo::ResourceTypeValidator
     validates_each :file, allow_blank: true, allow_nil: true do |rec, att, val|
-      rec.errors.add(att, "< #{val} > cannot be found at \'#{rec.import_path}\'") unless PFFile.exist?(rec, val)
+      rec.errors.add(att, "< #{val} > cannot be found at '#{rec.import_path}'") unless PFFile.exist?(rec, val)
     end
 
     def attributes

--- a/spec/lib/tenejo/preflight_spec.rb
+++ b/spec/lib/tenejo/preflight_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Tenejo::Preflight do
   context "a file that has unmapped header names" do
     let(:graph) { described_class.read_csv("spec/fixtures/csv/unmapped.csv", "spec/fixtures/images/uploads") }
     it "records a warning for that row" do
-      expect(graph.warnings).to include "The column \'frankabillity\' is unknown and will be ignored"
+      expect(graph.warnings).to include "The column 'frankabillity' is unknown and will be ignored"
     end
   end
 
@@ -81,7 +81,7 @@ RSpec.describe Tenejo::Preflight do
     let(:graph) { described_class.read_csv("spec/fixtures/csv/fancy.csv", "spec/fixtures/images/uploads") }
 
     it "gives a warning" do
-      expect(graph.warnings.join).to include 'Resource Type \'Photos\' is not recognized'
+      expect(graph.warnings.join).to include "Resource Type 'Photos' is not recognized"
     end
   end
 
@@ -108,7 +108,7 @@ RSpec.describe Tenejo::Preflight do
     end
 
     it "warns about disconnected works" do
-      expect(graph.warnings).to include "Row 10: Could not find parent \'NONA\'; work \'MPC009\' will be created without a parent if you continue."
+      expect(graph.warnings).to include "Row 10: Could not find parent 'NONA'; work 'MPC009' will be created without a parent if you continue."
     end
 
     it "connects works and collections with parents" do
@@ -118,11 +118,11 @@ RSpec.describe Tenejo::Preflight do
     end
 
     it "warns when work has no parent" do
-      expect(graph.warnings).to include "Row 3: Could not find parent \'NONEXISTENT\'; collection \'NONACOLLECTION\' will be created without a parent if you continue."
+      expect(graph.warnings).to include "Row 3: Could not find parent 'NONEXISTENT'; collection 'NONACOLLECTION' will be created without a parent if you continue."
     end
 
     it "warns files without parent in sheet" do
-      expect(graph.warnings).to include "Row 6: Could not find parent work \'WHUT?\' for file \'MN-02 2.png\' - the file will be ignored"
+      expect(graph.warnings).to include "Row 6: Could not find parent work 'WHUT?' for file 'MN-02 2.png' - the file will be ignored"
     end
 
     it "parses out object types" do
@@ -142,7 +142,7 @@ RSpec.describe Tenejo::Preflight do
     end
 
     it "includes warnings in the graph" do
-      expect(graph.warnings.join).to include "Could not find parent \'NONEXISTENT\'"
+      expect(graph.warnings.join).to include "Could not find parent 'NONEXISTENT'"
     end
 
     describe "graph structure" do
@@ -217,7 +217,7 @@ RSpec.describe Tenejo::Preflight do
     it "restricts resource type" do
       rec.resource_type = ["Book", "foo"]
       expect(rec.valid?).to eq false # there are other errors in the example
-      expect(rec.warnings[:resource_type]).to eq ["Resource Type \'foo\' is not recognized and will be omitted."]
+      expect(rec.warnings[:resource_type]).to eq ["Resource Type 'foo' is not recognized and will be omitted."]
     end
 
     context "path checking" do
@@ -332,7 +332,7 @@ RSpec.describe Tenejo::Preflight do
         it 'validates with warnings' do
           expect(rec).to be_valid
           expect(rec.errors).to be_empty
-          expect(rec.warnings[:license]).to eq ["License \'#{license}\' is not recognized and will be omitted"]
+          expect(rec.warnings[:license]).to eq ["License '#{license}' is not recognized and will be omitted"]
           expect(rec.license).to be_empty
         end
       end
@@ -346,7 +346,7 @@ RSpec.describe Tenejo::Preflight do
         it 'discards invalid vocabulary entries' do
           expect(rec).to be_valid
           expect(rec.errors).to be_empty
-          expect(rec.warnings[:license]).to eq ["License \'not-a-valid-id-or-label\' is not recognized and will be omitted"]
+          expect(rec.warnings[:license]).to eq ["License 'not-a-valid-id-or-label' is not recognized and will be omitted"]
           expect(rec.license).to contain_exactly('https://creativecommons.org/licenses/by/4.0/',
                              'https://creativecommons.org/publicdomain/mark/1.0/')
         end
@@ -408,7 +408,28 @@ RSpec.describe Tenejo::Preflight do
         it "get set to undetermined" do
           expect(rec).to be_valid
           expect(rec.errors).to be_empty
-          expect(rec.warnings[:rights_statement]).to eq ["Rights Statement \'not-a-valid-id-or-label\' is not recognized and will be set to 'Copyright Undetermined'"]
+          expect(rec.warnings[:rights_statement]).to eq ["Rights Statement 'not-a-valid-id-or-label' is not recognized and will be set to 'Copyright Undetermined'"]
+          expect(rec.rights_statement).to eq ['https://rightsstatements.org/vocab/UND/1.0/']
+        end
+      end
+
+      context 'with inactive entries' do
+        # active entries have https://, older inactive entries use http://
+        let(:rights_statement) { 'http://rightsstatements.org/vocab/InC/1.0/' }
+        it "get set to undetermined" do
+          expect(rec).to be_valid
+          expect(rec.errors).to be_empty
+          expect(rec.warnings[:rights_statement]).to eq ["Rights Statement 'http://rightsstatements.org/vocab/InC/1.0/' is not recognized and will be set to 'Copyright Undetermined'"]
+          expect(rec.rights_statement).to eq ['https://rightsstatements.org/vocab/UND/1.0/']
+        end
+      end
+
+      context 'with inexact matches' do
+        let(:rights_statement) { 'Copyright' }
+        it "get set to undetermined" do
+          expect(rec).to be_valid
+          expect(rec.errors).to be_empty
+          expect(rec.warnings[:rights_statement]).to eq ["Rights Statement 'Copyright' is not recognized and will be set to 'Copyright Undetermined'"]
           expect(rec.rights_statement).to eq ['https://rightsstatements.org/vocab/UND/1.0/']
         end
       end
@@ -427,7 +448,7 @@ RSpec.describe Tenejo::Preflight do
     it "restricts resource type" do
       rec.resource_type = ["foo"]
       expect(rec.valid?).to eq false # there are other errors in the example
-      expect(rec.warnings[:resource_type].join).to include "\'foo\' is not recognized and will be omitted."
+      expect(rec.warnings[:resource_type].join).to include "'foo' is not recognized and will be omitted."
     end
 
     it "can unpack" do
@@ -459,8 +480,8 @@ RSpec.describe Tenejo::Preflight do
       rec = described_class.new({ resource_type: "Poster|~|Airplane|~|Book|~|Bear" }, 1, Tenejo::DEFAULT_UPLOAD_PATH, 'placeholder for the graph')
       expect(rec.valid?).to eq false
       expect(rec.resource_type).to eq ["Poster", "Book"]
-      expect(rec.warnings[:resource_type].join).to include "\'Airplane\' is not recognized and will be omitted."
-      expect(rec.warnings[:resource_type].join).to include "\'Bear\' is not recognized and will be omitted."
+      expect(rec.warnings[:resource_type].join).to include "'Airplane' is not recognized and will be omitted."
+      expect(rec.warnings[:resource_type].join).to include "'Bear' is not recognized and will be omitted."
     end
   end
 
@@ -476,7 +497,7 @@ RSpec.describe Tenejo::Preflight do
     it "restricts resource type" do
       rec.resource_type = ["foo"]
       expect(rec.valid?).to eq false # there are other errors in the example
-      expect(rec.warnings[:resource_type].join).to include "\'foo\' is not recognized and will be omitted."
+      expect(rec.warnings[:resource_type].join).to include "'foo' is not recognized and will be omitted."
     end
   end
 


### PR DESCRIPTION
We realized that too many rights statements were too similar and a user might inadvertently enter "Copyright" which could produce ambiguous and surprising results.

This change requires an exact match on either the identifier or the label.

This change also restricts matches to active vocabulary entries.