### PR TITLE
Fix Stack Too Deep errors

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,14 @@
+version: "2"
+
+exclude_patterns:
+  - config/
+  - db/
+  - public/
+  - spec/
+  - tmp/
+  - vendor/
+  - "**/node_modules/"
+  - "**/spec/"
+  - "**/test/"
+  - "**/vendor/"
+  - app/extensions/extended_bounded_description.rb

--- a/app/extensions/extended_bounded_description.rb
+++ b/app/extensions/extended_bounded_description.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+require 'active_triples/util/extended_bounded_description'
+
+ActiveTriples::ExtendedBoundedDescription.class_eval do
+  # @param source_graph  [RDF::Queryable]
+  # @param starting_node [RDF::Term]
+  # @param ancestors     [Array<RDF::Term>] default: []
+  def initialize(source_graph, starting_node, ancestors = [])
+    @source_graph  = source_graph
+    @starting_node = starting_node
+    @ancestors     = Set.new(*ancestors) # Replaces array in original implementation
+  end
+
+  # Replaces original recursive method with iterative implementation
+  def each_statement
+    if block_given?
+      nodes_to_process = [] << starting_node
+
+      while nodes_to_process.any?
+        current_node = nodes_to_process.pop
+        ancestors << current_node
+        statements = source_graph.query(subject: current_node).each
+        statements.each_statement do |statement|
+          yield statement
+          object = statement.object
+          nodes_to_process.push(object) unless object.literal? || ancestors.include?(object)
+        end
+      end
+
+    end # block given
+    enum_statement
+  end
+
+  alias_method :each, :each_statement
+end


### PR DESCRIPTION
**ISSUE**
The ActiveTriples library implements a recursive graph traversal that results in stack-too-deep exceptions.

see https://gitlab.com/no_reply/ActiveTriples/-/blob/v1.1.0/lib/active_triples/util/extended_bounded_description.rb#L65-66

**SOLUTION**
* Refactor the `.each_statement` method to use iteration instead of recursion
* Use a Set instead of Array to speed up ancestor lookup

**NOTE**
Also adds a CodeClimate config file to repo

See relevant CodeClimate documentation
* https://docs.codeclimate.com/docs/advanced-configuration
* https://docs.codeclimate.com/docs/default-analysis-configuration#sample-codeclimateyml