### PR TITLE
Use collection, work, and file counts persisted in DB

### DIFF
--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -10,16 +10,4 @@ class Job < ApplicationRecord
   def graph
     @memo ||= Tenejo::Graph.from(attribute(:graph))
   end
-
-  def collections
-    graph.collections.count
-  end
-
-  def works
-    graph.works.count
-  end
-
-  def files
-    graph.files.count
-  end
 end

--- a/spec/views/jobs/show.html.erb_spec.rb
+++ b/spec/views/jobs/show.html.erb_spec.rb
@@ -10,15 +10,14 @@ RSpec.describe "jobs/show", type: :view do
        label: "test job",
        user: user,
        status: :completed,
-       graph: Tenejo::Graph.new
+       collections: 11,
+       works: 13,
+       files: 17
      )
   }
 
   # Scaffold generated test - should be replaced when additional functionality is developed
-  it "renders attributes in <p>" do
-    allow(job.graph).to receive(:collections).and_return(Array.new(11))
-    allow(job.graph).to receive(:works).and_return(Array.new(13))
-    allow(job.graph).to receive(:files).and_return(Array.new(17))
+  it "renders attributes in <p>", :aggregate_failures do
     assign(:job, job)
     render
     expect(rendered).to match('Type')


### PR DESCRIPTION
Object counts correlate directly to the source CSV and can never change.  Therefore, we can persist the counts as part of the base Job record and avoid the cost of dynamically recalculating them.

Reference schema change:
https://github.com/curationexperts/tenejo/pull/26/files#diff-c17e1dadf0e34c4d724a4044a37c2cb25903aed6f3be82072aba440cc0d87fc6

LOAD TIMES:
Before: 9.3s
After: 3.6s

<img width="1919" alt="jobs-load-times-before" src="https://user-images.githubusercontent.com/3064318/191570305-9bc9334e-9138-450f-aa97-723c9e5b9a5a.png">

<img width="1919" alt="jobs-load-times-after" src="https://user-images.githubusercontent.com/3064318/191570303-ba5efd8c-6adc-48c7-bef2-ae62ef2c8d81.png">

 