### PR TITLE
Refactor works to be independent of files

### DIFF
--- a/app/lib/tenejo/pf_object.rb
+++ b/app/lib/tenejo/pf_object.rb
@@ -250,24 +250,12 @@ module Tenejo
       ALL_FIELDS.each_with_object(super) { |x, m| m[x.to_sym] = nil; }
     end
 
-    def initialize(row = {}, lineno = 0, import_path = nil, graph = nil)
-      @files = []
-      @import_path = import_path
-      return unless graph
-      graph.detached_files += unpack_files_from_work(row, lineno, import_path) if row[:files]
-      row.delete(:files)
+    def initialize(row = {}, lineno = 0, _import_path = nil, _graph = nil)
       super(row, lineno)
     end
 
-    def unpack_files_from_work(row, lineno, import_path)
-      files = CSV::Row.new(row.headers, row.fields)
-      files[:parent] = files[:identifier]
-      files[:object_type] = "file"
-      PFFile.unpack(files, lineno, import_path)
-    end
-
     def self.singular_fields
-      @singular_fields ||= (ALL_FIELDS - Work.properties.select { |_k, v| v["multiple"] }.keys.map(&:to_sym)).sort
+      @singular_fields ||= ALL_FIELDS - ([:files] + Work.properties.select { |_k, v| v["multiple"] }.keys.map(&:to_sym))
     end
   end
 end

--- a/app/lib/tenejo/preflight.rb
+++ b/app/lib/tenejo/preflight.rb
@@ -52,7 +52,7 @@ module Tenejo
     end
 
     def self.process_csv(input, import_path = DEFAULT_UPLOAD_PATH) # rubocop:disable Metrics/CyclomaticComplexity
-      graph = Graph.new
+      graph = Graph.new(import_path)
       graph.add_fatal_error("No manifest present") and return graph unless input
       begin
         csv = CSV.new(input, headers: true, return_headers: true, skip_blanks: true,
@@ -63,7 +63,7 @@ module Tenejo
         check_unknown_headers(headers, graph)
         csv.each do |row|
           next unless check_length(row, headerlen, csv.lineno, graph)
-          graph.consume(row, import_path, csv.lineno)
+          graph.consume(row, csv.lineno)
         end
         graph.add_fatal_error("No data was detected") if graph.empty?
         graph.finalize

--- a/app/views/jobs/_child.html.erb
+++ b/app/views/jobs/_child.html.erb
@@ -28,13 +28,13 @@
       <td class="type"><%= node.class.to_s.delete_prefix("Tenejo::PF").truncate(1, omission: "") %></td>
       <td class="visibility"><%= node.visibility %></td>
       <td class="collection_count">
-        <%= dasher(node.collections.count) %>
+        <%= dasher(node.collections&.count) %>
       </td>
       <td class="work_count">
-        <%= dasher(node.works.count) %>
+        <%= dasher(node.works&.count) %>
       </td>
       <td class="file_count">
-          <%= dasher(node.files.count) unless node.kind_of?Tenejo::PFFile%>
+          <%= dasher(node.files&.count) unless node.kind_of?Tenejo::PFFile%>
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
The code had two paths to handle packed files depending on the type of CSV row they appeared in.

This change
* Consolidates handling of packed files in the Tenejo::PFFile class
* Makes `import_path` an instance variable of the graph so we don't have to pass it through intermediate method calls
* Removes a duplicate definition of DEFAULT_UPLOAD_PATH which is also defined [in preflight.rb](https://github.com/curationexperts/tenejo/blob/v2.19.0/app/lib/tenejo/preflight.rb#L9)