### PR TITLE
Remove CodeClimate from CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,47 +60,11 @@ jobs:
 
             - samvera/install_solr_core
 
-            - run:
-                name: Install Code Climate test reporter
-                command: |
-                    curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-                    chmod +x ./cc-test-reporter
-                    ./cc-test-reporter before-build
-
             - samvera/parallel_rspec
-
-            - run:
-                name: Generate CC coverage
-                command: ./cc-test-reporter format-coverage -t simplecov -o "coverage/codeclimate.$CIRCLE_NODE_INDEX.json"
-
-
-            - persist_to_workspace:
-                root: coverage
-                paths: codeclimate.*.json
 
             - deploy:
                 command: curl -k https://coveralls.io/webhook?repo_token=${COVERALLS_REPO_TOKEN} -d "payload[build_num]=${CIRCLE_BUILD_NUM}&payload[status]=done"
 
-    coverage:
-        docker:
-            - image: cimg/ruby:2.7.4-browsers
-        working_directory: ~/project
-        parallelism: 1
-        steps:
-            - attach_workspace:
-                at: /tmp/codeclimate
-
-            - run:
-                name: Install Code Climate test reporter
-                command: |
-                    curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-                    chmod +x ./cc-test-reporter
-
-            - run:
-                name: Upload Coverage
-                command: |
-                    ./cc-test-reporter sum-coverage --output='/tmp/codeclimate/summed_coverage.json' /tmp/codeclimate/codeclimate.*.json
-                    ./cc-test-reporter upload-coverage --input='/tmp/codeclimate/summed_coverage.json'
 
     deploy-job:
         parameters:
@@ -132,10 +96,6 @@ workflows:
         jobs:
             - build:
                 name: testing
-            - coverage:
-                name: codeclimate
-                requires:
-                    - testing
             - deploy-job:
                 requires:
                     - testing


### PR DESCRIPTION
We have github configured to run CodeClimate independely and don't need to be running it twice.