### PR TITLE
Improve CodeClimate and Coveralls reporting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 orbs:
     samvera: samvera/circleci-orb@1.0.3
-    browser-tools: circleci/browser-tools@1.2.4
+
 jobs:
     build:
         parameters:
@@ -60,47 +60,7 @@ jobs:
 
             - samvera/install_solr_core
 
-            - run:
-                name: Install Code Climate test reporter
-                command: |
-                    curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-                    chmod +x ./cc-test-reporter
-                    ./cc-test-reporter before-build
-
             - samvera/parallel_rspec
-
-            - run:
-                name: Generate CC coverage
-                command: ./cc-test-reporter format-coverage -t simplecov -o "coverage/codeclimate.$CIRCLE_NODE_INDEX.json"
-
-
-            - persist_to_workspace:
-                root: coverage
-                paths: codeclimate.*.json
-
-            - deploy:
-                command: curl -k https://coveralls.io/webhook?repo_token=${COVERALLS_REPO_TOKEN} -d "payload[build_num]=${CIRCLE_BUILD_NUM}&payload[status]=done"
-
-    coverage:
-        docker:
-            - image: cimg/ruby:2.7.4-browsers
-        working_directory: ~/project
-        parallelism: 1
-        steps:
-            - attach_workspace:
-                at: /tmp/codeclimate
-
-            - run:
-                name: Install Code Climate test reporter
-                command: |
-                    curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-                    chmod +x ./cc-test-reporter
-
-            - run:
-                name: Upload Coverage
-                command: |
-                    ./cc-test-reporter sum-coverage --output='/tmp/codeclimate/summed_coverage.json' /tmp/codeclimate/codeclimate.*.json
-                    ./cc-test-reporter upload-coverage --input='/tmp/codeclimate/summed_coverage.json'
 
     deploy-job:
         parameters:
@@ -132,10 +92,6 @@ workflows:
         jobs:
             - build:
                 name: testing
-            - coverage:
-                name: codeclimate
-                requires:
-                    - testing
             - deploy-job:
                 requires:
                     - testing

--- a/Gemfile
+++ b/Gemfile
@@ -59,12 +59,11 @@ gem 'whenever', group: 'production'
 
 group :test do
   gem 'capybara'
-  gem 'coveralls', require: false
+  gem 'coveralls_reborn', '~> 0.25.0'
   gem 'factory_bot_rails'
   gem 'rails-controller-testing'
   gem 'rspec-rails'
   gem 'rspec_junit_formatter'
-  gem 'simplecov_json_formatter'
   gem 'webdrivers'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -190,12 +190,11 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.10)
     connection_pool (2.3.0)
-    coveralls (0.8.23)
-      json (>= 1.8, < 3)
-      simplecov (~> 0.16.1)
-      term-ansicolor (~> 1.3)
-      thor (>= 0.19.4, < 2.0)
-      tins (~> 1.6)
+    coveralls_reborn (0.25.0)
+      simplecov (>= 0.18.1, < 0.22.0)
+      term-ansicolor (~> 1.6)
+      thor (>= 0.20.3, < 2.0)
+      tins (~> 1.16)
     crass (1.0.6)
     declarative (0.0.20)
     declarative-builder (0.1.0)
@@ -889,12 +888,12 @@ GEM
     simple_form (5.1.0)
       actionpack (>= 5.2)
       activemodel (>= 5.2)
-    simplecov (0.16.1)
+    simplecov (0.21.2)
       docile (~> 1.1)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.2)
-    simplecov_json_formatter (0.1.3)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
     slop (4.9.2)
     solr_wrapper (3.1.2)
       http
@@ -940,7 +939,7 @@ GEM
     thor (1.2.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    tins (1.31.0)
+    tins (1.31.1)
       sync
     tinymce-rails (6.0.2)
       railties (>= 3.1.1)
@@ -1013,7 +1012,7 @@ DEPENDENCIES
   capistrano-rails
   capybara
   coffee-rails (~> 4.2)
-  coveralls
+  coveralls_reborn (~> 0.25.0)
   devise
   devise-guests (~> 0.6)
   devise_invitable (~> 2.0.0)
@@ -1041,7 +1040,6 @@ DEPENDENCIES
   rspec_junit_formatter
   sass-rails (~> 5.0)
   sidekiq (~> 6.4)
-  simplecov_json_formatter
   solr_wrapper (>= 0.3)
   terser
   turbolinks (~> 5)


### PR DESCRIPTION
**CodeClimate**
We have GitHub and CircleCI both configured to run CodeClimate independely and don't need to be running it twice.  This change removes the related configuration form CircleCI.  Going forward, we will continue to use GitHub actions to trigger CodeClimate.

**Coveralls**
We have not been getting coverage reporting since March 2022 due to dependency incompatibilities with the `coveralls` gem.  The gem is no longer being maintained.  The last update occured in 2019: https://rubygems.org/gems/coveralls

The `coveralls_reborn` gem is being actively maintained by the same authors and appears to be the direct replacement:
https://rubygems.org/gems/coveralls_reborn