### PR TITLE
Move metadata definitions from Hyrax into Tenejo

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -7,7 +7,7 @@ class Collection < ActiveFedora::Base
     index.as :stored_sortable
   end
   # You can replace these metadata if they're not suitable
-  include Hyrax::BasicMetadata
+  include ::Tenejo::BasicMetadata
   self.indexer = Hyrax::CollectionWithBasicMetadataIndexer
 
   def self.terms

--- a/app/models/concerns/hyrax/core_metadata.rb
+++ b/app/models/concerns/hyrax/core_metadata.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+module Hyrax
+  # These are the metadata elements that Hyrax internally requires of
+  # all managed Collections, Works and FileSets will have.
+  module CoreMetadata
+    extend ActiveSupport::Concern
+
+    included do
+      property :depositor, predicate: ::RDF::URI.new('http://id.loc.gov/vocabulary/relators/dpt'), multiple: false do |index|
+        index.as :symbol, :stored_searchable
+      end
+
+      property :title, predicate: ::RDF::Vocab::DC.title do |index|
+        index.as :stored_searchable, :facetable
+      end
+
+      def first_title
+        title.first
+      end
+
+      # We reserve date_uploaded for the original creation date of the record.
+      # For example, when migrating data from a fedora3 repo to fedora4,
+      # fedora's system created date will reflect the date when the record
+      # was created in fedora4, but the date_uploaded will preserve the
+      # original creation date from the old repository.
+      property :date_uploaded, predicate: ::RDF::Vocab::DC.dateSubmitted, multiple: false do |index|
+        index.type :date
+        index.as :stored_sortable
+      end
+
+      property :date_modified, predicate: ::RDF::Vocab::DC.modified, multiple: false do |index|
+        index.type :date
+        index.as :stored_sortable
+      end
+    end
+  end
+end

--- a/app/models/concerns/tenejo/basic_metadata.rb
+++ b/app/models/concerns/tenejo/basic_metadata.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+module Tenejo
+  # An optional model mixin to define some simple properties. This must be mixed
+  # after all other properties are defined because no other properties will
+  # be defined once  accepts_nested_attributes_for is called
+  module BasicMetadata
+    extend ActiveSupport::Concern
+
+    included do # rubocop:disable Metrics/BlockLength
+      property :alternative_title, predicate: ::RDF::Vocab::DC.alternative
+
+      property :label, predicate: ActiveFedora::RDF::Fcrepo::Model.downloadFilename, multiple: false
+
+      property :relative_path, predicate: ::RDF::URI.new('http://scholarsphere.psu.edu/ns#relativePath'), multiple: false
+
+      property :import_url, predicate: ::RDF::URI.new('http://scholarsphere.psu.edu/ns#importUrl'), multiple: false
+      property :resource_type, predicate: ::RDF::Vocab::DC.type
+      property :creator, predicate: ::RDF::Vocab::DC11.creator
+      property :contributor, predicate: ::RDF::Vocab::DC11.contributor
+      property :description, predicate: ::RDF::Vocab::DC11.description
+      property :abstract, predicate: ::RDF::Vocab::DC.abstract
+      property :keyword, predicate: ::RDF::Vocab::SCHEMA.keywords
+      # Used for a license
+      property :license, predicate: ::RDF::Vocab::DC.license, multiple: true
+
+      property :rights_notes, predicate: ::RDF::URI.new('http://purl.org/dc/elements/1.1/rights'), multiple: true
+
+      # This is for the rights statement
+      property :rights_statement, predicate: ::RDF::Vocab::EDM.rights
+      property :access_right, predicate: ::RDF::Vocab::DC.accessRights
+      property :publisher, predicate: ::RDF::Vocab::DC11.publisher
+      property :date_created, predicate: ::RDF::Vocab::DC.created
+      property :subject, predicate: ::RDF::Vocab::DC11.subject
+      property :language, predicate: ::RDF::Vocab::DC11.language
+      property :identifier, predicate: ::RDF::Vocab::DC.identifier
+      property :based_near, predicate: ::RDF::Vocab::FOAF.based_near, class_name: Hyrax::ControlledVocabularies::Location
+      property :related_url, predicate: ::RDF::RDFS.seeAlso
+      property :bibliographic_citation, predicate: ::RDF::Vocab::DC.bibliographicCitation
+      property :source, predicate: ::RDF::Vocab::DC.source
+
+      id_blank = proc { |attributes| attributes[:id].blank? }
+
+      class_attribute :controlled_properties
+      self.controlled_properties = [:based_near]
+      accepts_nested_attributes_for :based_near, reject_if: id_blank, allow_destroy: true
+    end
+  end
+end

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -16,7 +16,7 @@ class Work < ActiveFedora::Base
   # This must be included at the end, because it finalizes the metadata
   # schema (by adding accepts_nested_attributes)
 
-  include ::Hyrax::BasicMetadata
+  include ::Tenejo::BasicMetadata
 
   def self.terms
     @metadata ||= properties.keys.sort.map(&:to_sym)


### PR DESCRIPTION
As the first step to implementing a custom Tenejo metadata model, refactor so the relevant definitions are moved from Hyrax into the local application.

This commit does not change any field definitions from their Hyrax equivalents.

NOTES:
* BasicMetadata is directly referenced in the local codebase from Collections and Works and can be moved into the Tenejo namespace for clarity
* Hyrax::FileSetBehavior still references Hyrax::BasicMetadata inside the Hyrax engine, so we may have to address that later
* Hyrax::CoreMetadata is included in many modules in the engine and therefore we need to override it using the same namespace see https://github.com/samvera/hyrax/search?q=CoreMetadata