### PR TITLE
Fix logo upload in themes

### DIFF
--- a/app/controllers/themes_controller.rb
+++ b/app/controllers/themes_controller.rb
@@ -75,8 +75,7 @@ class ThemesController < ApplicationController
 
   # Only allow a list of trusted parameters through.
   def theme_params
-    params.require(:theme).permit(Theme::DEFAULTS.keys << :logo)
-    params.require(:theme).permit(Theme::DEFAULTS.keys << :hero_image)
+    params.require(:theme).permit(Theme::DEFAULTS.keys + [:logo, :hero_image])
   end
 
   # Restrict theme access to admins


### PR DESCRIPTION
**ISSUE**
The old code wiped out the logo field when it added the hero image field to the parameter list.

**FIX**
Add both fields as an array.