### PR TITLE
Fix identifier display in jobs list

### DIFF
--- a/app/lib/tenejo/csv_importer.rb
+++ b/app/lib/tenejo/csv_importer.rb
@@ -64,7 +64,7 @@ module Tenejo
 
     def ensure_thumbnails(node)
       return unless node.class == Tenejo::PFWork
-      work = Work.where(identifier_ssi: node.identifier.first)&.last
+      work = Work.where(identifier_ssi: node.identifier)&.last
       unless work
         @logger.error "CSV Importer couldn't find Work with primary_id #{node&.identifier} to attach thumbnail"
         return

--- a/app/views/jobs/_child.html.erb
+++ b/app/views/jobs/_child.html.erb
@@ -21,7 +21,7 @@
         <%= status_span_generator(node.status) %>
       </td>
       <td class="identifier">
-        <%= node.identifier.first %>
+        <%= node.identifier %>
       </td>
       <td class="lineno"><%= node.lineno %></td>
       <td class="index"><%= order || raw("&ndash;") %></td>


### PR DESCRIPTION
**ISSUE**
We missed some `.first` methods from when identifier was an arrary
- now they return the first letter from the string.  This change gives us the full identifier string we want :)