### PR TITLE
Experimentally adds batched IngestLocalFile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'bcrypt_pbkdf'
 gem 'ed25519'
 gem 'rails', '~> 5.2'
 gem 'sidekiq', '~> 6.4'
+gem 'sidekiq-batch'
 # Use Puma as the app server
 gem 'dotenv-rails', '~> 2.2.1'
 gem 'okcomputer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -880,6 +880,8 @@ GEM
       connection_pool (>= 2.2.5)
       rack (~> 2.0)
       redis (>= 4.5.0, < 5)
+    sidekiq-batch (0.1.8)
+      sidekiq (>= 3)
     signet (0.16.1)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.0)
@@ -1040,6 +1042,7 @@ DEPENDENCIES
   rspec_junit_formatter
   sass-rails (~> 5.0)
   sidekiq (~> 6.4)
+  sidekiq-batch
   solr_wrapper (>= 0.3)
   terser
   turbolinks (~> 5)

--- a/app/lib/tenejo/csv_importer.rb
+++ b/app/lib/tenejo/csv_importer.rb
@@ -247,17 +247,23 @@ module Tenejo
       # - existing work, update files - NOT IMPLEMENTED YET
       # - existing work, add files - NOT IMPLEMENTED YET
       # - existing work, delete files - NOT SUPPORTED
-      file_sets = pfwork.children.filter { |x| x.is_a? Tenejo::PFFile }.map do |pffile|
-        file_set = FileSet.new
-        file_set.label = File.basename(pffile.file)
-        file_set.title = pffile.try(:title) ? [pffile.title] : [file_set.label]
-        file_set.visibility = pffile.visibility
-        file_set.save!
-        local_path = File.join(pffile.import_path, pffile.file)
-        update_status(pffile, 'in_progress', 'completed') do
-          IngestLocalFileJob.perform_now(file_set, local_path, @job.user)
+      batch = Sidekiq::Batch.new
+      batch.description="Process the filesets"
+
+      file_sets = []
+      batch.jobs do
+        pfwork.children.filter { |x| x.is_a? Tenejo::PFFile }.inject(file_sets) do |m, pffile|
+          file_set = FileSet.new
+          file_set.label = File.basename(pffile.file)
+          file_set.title = pffile.try(:title) ? [pffile.title] : [file_set.label]
+          file_set.visibility = pffile.visibility
+          file_set.save!
+          local_path = File.join(pffile.import_path, pffile.file)
+          update_status(pffile, 'in_progress', 'completed') do
+            IngestLocalFileJob.perform_later(file_set, local_path, @job.user)
+          end
+          m<< file_set
         end
-        file_set
       end
       # NOTE: this code does not invoke the :after_fileset_create callback which generates notifications
       # That's probably ok in this context


### PR DESCRIPTION
see: https://github.com/mperham/sidekiq/wiki/Batches

This *should* enable the ingest process to utilize more resources
while handling file ingest.

IngestLocalFileJob will be performed asynchronously, but all of its
sub-jobs will still be inlined. this should allow concurrency during
characterization & file transcoding.

The batch block will enqueue IngestLocalFileJobs and block until the
sub-jobs complete. in theory, which is nice.
