### PR TITLE
Fix Job show page errors for exports

### DIFF
--- a/app/views/jobs/_card.html.erb
+++ b/app/views/jobs/_card.html.erb
@@ -42,15 +42,15 @@
             <div class="row">
               <dl class="col-xs-4">
                 <dt class="text-nowrap">Collections</dt>
-                <dd class="job-number job-collections"><%= dasher(@job.graph.collections.size)  %></dd>
+                <dd class="job-number job-collections"><%= dasher(@job.collections)  %></dd>
               </dl>
               <dl class="col-xs-4">
                 <dt class="text-nowrap">Works</dt>
-                <dd class="job-number job-works"><%= dasher(@job.graph.works.size) %></dd>
+                <dd class="job-number job-works"><%= dasher(@job.works) %></dd>
               </dl>
               <dl class="col-xs-4">
                 <dt class="text-nowrap">Files</dt>
-                <dd class="job-number job-files"><%= dasher(@job.graph.files.size)%></dd>
+                <dd class="job-number job-files"><%= dasher(@job.files)%></dd>
               </dl>
             </div>
           </div>

--- a/spec/views/preflights/show.html.erb_spec.rb
+++ b/spec/views/preflights/show.html.erb_spec.rb
@@ -13,7 +13,10 @@ RSpec.describe "preflights/show", type: :view do
       manifest: tempfile,
       status: :completed,
       completed_at: completion_time,
-      graph: graph
+      graph: graph,
+      collections: 0,
+      works: 13,
+      files: 17
     )
   }
 
@@ -32,7 +35,7 @@ RSpec.describe "preflights/show", type: :view do
     expect(rendered).to have_selector('.job-status', text: 'Completed')
     expect(rendered).to have_selector('.job-created_at', text: job.created_at)
     expect(rendered).to have_selector('.job-completed_at', text: completion_time)
-    expect(rendered).to have_selector('.job-collections', text: "–")
+    expect(rendered).to have_selector('.job-collections', text: '–') # this is an &ndash; vs a minus sign, i.e. '–' vs. '-'
     expect(rendered).to have_selector('.job-works', text: '13')
     expect(rendered).to have_selector('.job-files', text: '17')
     expect(rendered).to have_link(text: 'empty.csv')


### PR DESCRIPTION
**ISSUE**
Trying to view an export page threw an error when trying to calculate the collection, work, and file counts from the graph - since export job do not have a graph.

**FIX**
Use the collection, work, and file counts saved directly to the job record.