### PR TITLE
Allow URLs as file paths in CSV imports

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -38,11 +38,11 @@ module ApplicationHelper
       status_classes = 'status-completed'
     when 'In Progress'
       status_classes = 'status-in-progress'
-    when 'Unknown'
+    when 'Unknown', 'Expired'
       status_classes = 'status-unknown'
     else
       status_classes = 'status-unrecognized'
-      status_text = 'Unk'
+      status_text = '-?-'
     end
     tag.span(status_text, class: 'job-status badge rounded-pill ' + status_classes)
   end

--- a/spec/fixtures/csv/file_id_test.csv
+++ b/spec/fixtures/csv/file_id_test.csv
@@ -1,20 +1,20 @@
-"Identifier","Object Type","Parent","Title","Description","Creator","Rights Statement","Visibility","Files","Comment"
-CARDS-0001-H,Work,,Hearts,"Child work with directly attached file, plus child works (file is reused in a child)",T. C. Oyun Kagitlari Monopolu,Copyright Undetermined,Public,hearts/As-Cœurs-Recto.tiff,
-CARDS-0001-H-A,work,CARDS-0001-H,Ace of Hearts,Child work (2-deep),T. C. Oyun Kagitlari Monopolu,Copyright Not Evaluated,open,hearts/As-Cœurs-Recto.tiff|~|hearts/As-Cœurs-Verso.tiff,
-"CARDS-0001-H-J","work","CARDS-0001-H","Jack of Hearts","Child work (2-deep)","T. C. Oyun Kagitlari Monopolu","Copyright Not Evaluated","open",hearts/Valet-Cœurs-Recto.tiff|~|hearts/Valet-Cœurs-Verso.tiff,
-"CARDS-0001-H-Q","work","CARDS-0001-H","Queen of Hearts","Child work (2-deep)","T. C. Oyun Kagitlari Monopolu","Copyright Not Evaluated","open",hearts/Dame-Cœurs-Recto.tiff|~|hearts/Dame-Cœurs-Verso.tiff,
-"CARDS-0001-H-K","work","CARDS-0001-H","King of Hearts","Child work (2-deep)","T. C. Oyun Kagitlari Monopolu","Copyright Not Evaluated","open",hearts/Roi-Cœurs-Recto.tiff|~|hearts/Roi-Cœurs-Verso.tiff,
-,,,,,,,,,
-"CARDS-0001-D","Work",,"Diamonds","Child work with no direct files","T. C. Oyun Kagitlari Monopolu","Copyright Not Evaluated","public",,
-"CARDS-0001-D-A","File","CARDS-0001-D","Ace of Diamonds","File with packed file list","T. C. Oyun Kagitlari Monopolu","Copyright Not Evaluated","public",diamonds/As-Carreaux-Recto.tiff|~|/diamonds/As-Carreaux-Verso.tiff,
-"","File","CARDS-0001-D","Jack of Diamonds",Single file with auto-assigned Identifier,"T. C. Oyun Kagitlari Monopolu","Copyright Not Evaluated","public",diamonds/Valet-Carreaux-Recto.tiff,
-"","f","CARDS-0001-D","Queen of Diamonds",Packed file with auto-assigned Identifier,"T. C. Oyun Kagitlari Monopolu","Copyright Not Evaluated","public",diamonds/Dame-Carreaux-Recto.tiff|~|/diamonds/Dame-Carreaux-Verso.tiff,
-"CARDS-0001-D-K","f","CARDS-0001-D","King of Diamonds","File with packed file list","T. C. Oyun Kagitlari Monopolu","Copyright Not Evaluated","public",diamonds/Roi-Carreaux-Recto.tiff|~|/diamonds/Roi-Carreaux-Verso.tiff,
-,,,,,,,,,
-"CARDS-0001-C","Work",,"Clubs","Child work with packed file list","T. C. Oyun Kagitlari Monopolu","Copyright Not Evaluated","public",/clubs/As-Trefles-Recto.tiff|~|/clubs/Roi-Trefles-Recto.tiff|~|/clubs/Dame-Trefles-Recto.tiff|~|/clubs/Valet-Trefles-Recto.tiff,
-,,,,,,,,,
-"CARDS-0001-S","Work",,"Spades","Child work with no direct files","T. C. Oyun Kagitlari Monopolu","Copyright Not Evaluated","public",,
-"CARDS-0001-S-A","File","CARDS-0001-S","Ace of Spades","File with single file","T. C. Oyun Kagitlari Monopolu","Copyright Not Evaluated","public",./spades/As-Piques-Recto.tiff,
-"CARDS-0001-S-J","File","CARDS-0001-S","Jack of Spades","File with single file","T. C. Oyun Kagitlari Monopolu","Copyright Not Evaluated","public",/spades/Valet-Piques-Recto.tiff,
-"CARDS-0001-S-Q","File","CARDS-0001-S","Queen of Spades","File with single file","T. C. Oyun Kagitlari Monopolu","Copyright Not Evaluated","public",spades/Dame-Piques-Recto.tiff,
-"CARDS-0001-S-K","File","CARDS-0001-S","King of Spades","File with single file","T. C. Oyun Kagitlari Monopolu","Copyright Not Evaluated","public",spades/Roi-Piques-Recto.tiff,
+Identifier,Object Type,Parent,Title,Description,Creator,Rights Statement,Visibility,Files
+CARDS-0001-H,Work,,Hearts,"Child work with directly attached file, plus child works (file is reused in a child)",T. C. Oyun Kagitlari Monopolu,Copyright Undetermined,Public,https://dummy.org/hearts/As-Cœurs-Recto.tiff
+CARDS-0001-H-A,work,CARDS-0001-H,Ace of Hearts,Child work (2-deep),T. C. Oyun Kagitlari Monopolu,Copyright Not Evaluated,open,https://dummy.org/hearts/As-Cœurs-Recto.tiff|~|https://dummy.org/hearts/As-Cœurs-Verso.tiff
+CARDS-0001-H-J,work,CARDS-0001-H,Jack of Hearts,Child work (2-deep),T. C. Oyun Kagitlari Monopolu,Copyright Not Evaluated,open,https://dummy.org/hearts/Valet-Cœurs-Recto.tiff|~|https://dummy.org/hearts/Valet-Cœurs-Verso.tiff
+CARDS-0001-H-Q,work,CARDS-0001-H,Queen of Hearts,Child work (2-deep),T. C. Oyun Kagitlari Monopolu,Copyright Not Evaluated,open,https://dummy.org/hearts/Dame-Cœurs-Recto.tiff|~|https://dummy.org/hearts/Dame-Cœurs-Verso.tiff
+CARDS-0001-H-K,work,CARDS-0001-H,King of Hearts,Child work (2-deep),T. C. Oyun Kagitlari Monopolu,Copyright Not Evaluated,open,https://dummy.org/hearts/Roi-Cœurs-Recto.tiff|~|https://dummy.org/hearts/Roi-Cœurs-Verso.tiff
+,,,,,,,,
+CARDS-0001-D,Work,,Diamonds,Child work with no direct files,T. C. Oyun Kagitlari Monopolu,Copyright Not Evaluated,public,
+CARDS-0001-D-A,File,CARDS-0001-D,Ace of Diamonds,File with packed file list,T. C. Oyun Kagitlari Monopolu,Copyright Not Evaluated,public,https://dummy.org/diamonds/As-Carreaux-Recto.tiff|~|https://dummy.org/diamonds/As-Carreaux-Verso.tiff
+"",File,CARDS-0001-D,Jack of Diamonds,Single file with auto-assigned Identifier,T. C. Oyun Kagitlari Monopolu,Copyright Not Evaluated,public,https://dummy.org/diamonds/Valet-Carreaux-Recto.tiff
+"",f,CARDS-0001-D,Queen of Diamonds,Packed file with auto-assigned Identifier,T. C. Oyun Kagitlari Monopolu,Copyright Not Evaluated,public,https://dummy.org/diamonds/Dame-Carreaux-Recto.tiff|~|https://dummy.org/diamonds/Dame-Carreaux-Verso.tiff
+CARDS-0001-D-K,f,CARDS-0001-D,King of Diamonds,File with packed file list,T. C. Oyun Kagitlari Monopolu,Copyright Not Evaluated,public,https://dummy.org/diamonds/Roi-Carreaux-Recto.tiff|~|https://dummy.org/diamonds/Roi-Carreaux-Verso.tiff
+,,,,,,,,
+CARDS-0001-C,Work,,Clubs,Child work with packed file list,T. C. Oyun Kagitlari Monopolu,Copyright Not Evaluated,public,https://dummy.org/clubs/As-Trefles-Recto.tiff|~|https://dummy.org/clubs/Roi-Trefles-Recto.tiff|~|https://dummy.org/clubs/Dame-Trefles-Recto.tiff|~|https://dummy.org/clubs/Valet-Trefles-Recto.tiff
+,,,,,,,,
+CARDS-0001-S,Work,,Spades,Child work with no direct files,T. C. Oyun Kagitlari Monopolu,Copyright Not Evaluated,public,
+CARDS-0001-S-A,File,CARDS-0001-S,Ace of Spades,File with single file,T. C. Oyun Kagitlari Monopolu,Copyright Not Evaluated,public,https://dummy.org/spades/As-Piques-Recto.tiff
+CARDS-0001-S-J,File,CARDS-0001-S,Jack of Spades,File with single file,T. C. Oyun Kagitlari Monopolu,Copyright Not Evaluated,public,https://dummy.org/spades/Valet-Piques-Recto.tiff
+CARDS-0001-S-Q,File,CARDS-0001-S,Queen of Spades,File with single file,T. C. Oyun Kagitlari Monopolu,Copyright Not Evaluated,public,https://dummy.org/spades/Dame-Piques-Recto.tiff
+CARDS-0001-S-K,File,CARDS-0001-S,King of Spades,File with single file,T. C. Oyun Kagitlari Monopolu,Copyright Not Evaluated,public,https://dummy.org/spades/Roi-Piques-Recto.tiff

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -13,7 +13,7 @@ describe ApplicationHelper do
     end
 
     example "for unrecognized statuses" do
-      expect(helper.status_span_generator("it's complicated")).to include "Unk"
+      expect(helper.status_span_generator("it's complicated")).to include "-?-"
     end
 
     example "accepts symbols" do

--- a/spec/lib/tenejo/preflight_spec.rb
+++ b/spec/lib/tenejo/preflight_spec.rb
@@ -170,10 +170,6 @@ RSpec.describe Tenejo::Preflight do
     let(:diamonds) { graph.root.children[1] }
     let(:clubs) { graph.root.children[2] }
     let(:spades) { graph.root.children[3] }
-    before do
-      # Ignore file existence validations for these tests
-      allow(Tenejo::PFFile).to receive(:exist?).and_return(true)
-    end
     context "when explicit in the CSV" do
       example "for single files", :aggregate_failures do
         ace_of_spades = spades.children[0]


### PR DESCRIPTION
This change allows preflight and import to accept URLs instead of a local file path and name for the import file.

The importer currently marks these entries as "Expired" during import so we can process the rest of the file.

A future update will handle downloading files from the specified URL and passing it to the ingest code.