### PR TITLE
Ensure Other Identifiers shows up in edit and show views

### DIFF
--- a/app/forms/hyrax/work_form.rb
+++ b/app/forms/hyrax/work_form.rb
@@ -7,7 +7,7 @@ module Hyrax
                   :keyword, :subject, :resource_type, :resource_format, :genre, :extent,
                   :license, :rights_statement, :access_right, :rights_notes, :publisher,
                   :date_normalized, :date_created, :date_copyrighted, :date_issued, :date_accepted,
-                  :language, :identifier, :based_near, :related_url,
+                  :language, :identifier, :based_near, :related_url, :other_identifiers,
                   :representative_id, :thumbnail_id, :rendering_ids, :files,
                   :visibility_during_embargo, :embargo_release_date, :visibility_after_embargo,
                   :visibility_during_lease, :lease_expiration_date, :visibility_after_lease,

--- a/app/models/concerns/tenejo/basic_metadata.rb
+++ b/app/models/concerns/tenejo/basic_metadata.rb
@@ -10,7 +10,9 @@ module Tenejo
       property :identifier, predicate: ::RDF::Vocab::DC11.identifier, multiple: false do |index|
         index.as :stored_sortable
       end
-      property :other_identifiers, predicate: ::RDF::Vocab::DC.identifier
+      property :other_identifiers, predicate: ::RDF::Vocab::DC.identifier do |index|
+        index.as :symbol
+      end
       property :alternative_title, predicate: ::RDF::Vocab::DC.alternative
 
       property :label, predicate: ActiveFedora::RDF::Fcrepo::Model.downloadFilename, multiple: false

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -9,7 +9,8 @@ class SolrDocument
 
   # Make any metadata changes after module inclusions to override
   # https://github.com/samvera/hyrax/blob/v3.4.1/app/models/concerns/hyrax/solr_document/metadata.rb
-  attribute :identifier,       Solr::String, "identifier_ssi"
+  attribute :identifier, Solr::String, "identifier_ssi"
+  attribute :other_identifiers, Solr::Array, "other_identifiers_ssim"
   attribute :date_normalized,  Solr::String, "date_normalized_ssi"
   attribute :date_created,     Solr::String, "date_created_ssi"
   attribute :date_copyrighted, Solr::String, "date_copyrighted_ssi"

--- a/app/presenters/hyrax/work_presenter.rb
+++ b/app/presenters/hyrax/work_presenter.rb
@@ -5,6 +5,6 @@
 module Hyrax
   class WorkPresenter < Hyrax::WorkShowPresenter
     # Date fields
-    delegate :date_normalized, :date_created, :date_copyrighted, :date_accepted, :date_issued, :resource_format, :genre, :extent, to: :solr_document
+    delegate :other_identifiers, :date_normalized, :date_created, :date_copyrighted, :date_accepted, :date_issued, :resource_format, :genre, :extent, to: :solr_document
   end
 end

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -6,6 +6,7 @@
 <%= presenter.attribute_to_html(:publisher, render_as: :faceted, html_dl: true) %>
 <%= presenter.attribute_to_html(:language, render_as: :faceted, html_dl: true) %>
 <%= presenter.attribute_to_html(:identifier, render_as: :linked, search_field: 'identifier_tesim', html_dl: true) %>
+<%= presenter.attribute_to_html(:other_identifiers, html_dl: true) %>
 <%= presenter.attribute_to_html(:keyword, render_as: :faceted, html_dl: true) %>
 <%= presenter.attribute_to_html(:date_submitted, html_dl: true) %>
 <%= presenter.attribute_to_html(:date_modified, html_dl: true) %>

--- a/spec/views/hyrax/base/_attribute_rows.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_attribute_rows.html.erb_spec.rb
@@ -12,7 +12,9 @@ RSpec.describe 'hyrax/base/attribute_rows', type: :view do
                      resource_type_tesim: ['Map'],
                      resource_format_tesim: ['polar projection'],
                      genre_tesim: ['satellite imagery', 'false color'],
-                     extent_tesim: ['24 x 38 inches', '2 sheets'])
+                     extent_tesim: ['24 x 38 inches', '2 sheets'],
+                     identifier_ssi: 'TEST-000-1',
+                     other_identifiers_ssim: ['DOI:this', 'ARK:that', 'HDL:the-other-one'])
   end
   let(:ability) { double }
   let(:presenter) { Hyrax::WorkPresenter.new(solr_document, ability) }
@@ -31,5 +33,11 @@ RSpec.describe 'hyrax/base/attribute_rows', type: :view do
     expect(rendered).to have_selector('.attribute-resource_format', text: 'polar projection')
     expect(rendered).to have_selector('.attribute-genre', text: 'false color')
     expect(rendered).to have_selector('.attribute-extent', text: '2 sheets')
+  end
+
+  it 'displays identifiers', :aggregate_failures do
+    render 'hyrax/base/attribute_rows', presenter: presenter
+    expect(rendered).to have_selector('.attribute-identifier', text: 'TEST-000-1')
+    expect(rendered).to have_selector('.attribute-other_identifiers', text: 'HDL:the-other-one')
   end
 end


### PR DESCRIPTION
**ISSUE**
When we refactored `primary_identifier` --> `identifier` and added `other_identifiers`, we lost the display of `other_identifiers` because they had previously been highjacking built-in code for DC:identifier

**RESOLUTION**
Explicitly add `other_identifiers` to SolrDocument, WorkPresenter, WorkForm, and show view partial.  Also refactors identifier to be a symbol so searches won't try to tokenize identifiers.