### PR TITLE
Read the contact address configured in the environment

### DIFF
--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -25,7 +25,7 @@ Hyrax.config do |config|
   # config.rendering_predicate = ::RDF::DC.hasFormat
 
   # Email recipient of messages sent via the contact form
-  # config.contact_email = "repo-admin@example.org"
+  config.contact_email = ENV.fetch('CONTACT_US_EMAIL', 'contact@curationexperts.com')
 
   # Text prefacing the subject entered in the contact form
   # config.subject_prefix = "Contact form:"


### PR DESCRIPTION
The CONTACT_US_EMAIL environement varaible was not implemented anywhere in the Tenejo or Hyrax codebases.

This change sets the Hyrax contact e-mail to the value configured via CONTACT_US_EMAIL in the environment or defaults to `contact@curationexperts.com`.