### PR TITLE
Remove methods only used in tests

### DIFF
--- a/app/lib/tenejo/csv_importer.rb
+++ b/app/lib/tenejo/csv_importer.rb
@@ -7,29 +7,13 @@ module Tenejo
       @job = import_job
       @depositor = import_job.user.user_key
       @logger = Rails.logger
-      if preflight_errors.present?
+      if @job.graph&.fatal_errors.present?
         @job.status = :errored
         @job.completed_at = Time.current
       else
         @job.status = :submitted
       end
       @job.save
-    end
-
-    def csv_import_file_root
-      File.join(Hyrax.config.upload_path.call, 'ftp')
-    end
-
-    def preflight_errors
-      @job.graph&.fatal_errors
-    end
-
-    def preflight_warnings
-      @job.graph.warnings
-    end
-
-    def invalid_rows
-      @job.graph.invalids
     end
 
     def import

--- a/spec/lib/tenejo/csv_importer_file_spec.rb
+++ b/spec/lib/tenejo/csv_importer_file_spec.rb
@@ -35,8 +35,8 @@ RSpec.describe Tenejo::CsvImporter do
       @csv_import.import
 
       # make all the tests fail if we've somehow broken the test setup
-      expect(@csv_import.preflight_errors).to be_empty
-      expect(@csv_import.preflight_warnings).to be_empty
+      expect(import_job.graph.fatal_errors).to be_empty
+      expect(import_job.graph.warnings).to be_empty
     end
   end
 

--- a/spec/lib/tenejo/csv_importer_nesting_spec.rb
+++ b/spec/lib/tenejo/csv_importer_nesting_spec.rb
@@ -36,9 +36,10 @@ RSpec.describe Tenejo::CsvImporter do
   end
 
   it 'runs without errors', :aggregate_failures do
-    expect(@csv_import.preflight_errors).to be_empty
-    expect(@csv_import.invalid_rows).to be_empty
-    expect(@csv_import.preflight_warnings).to eq ["The column \'Comment\' is unknown and will be ignored"]
+    import_graph = @csv_import.instance_variable_get(:@job).graph
+    expect(import_graph.fatal_errors).to be_empty
+    expect(import_graph.invalids).to be_empty
+    expect(import_graph.warnings).to eq ["The column \'Comment\' is unknown and will be ignored"]
   end
 
   it 'sets error status', :aggregate_failures do

--- a/spec/lib/tenejo/csv_importer_spec.rb
+++ b/spec/lib/tenejo/csv_importer_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Tenejo::CsvImporter do
     # rubocop:disable RSpec/MessageSpies
     it "creates no objects" do
       csv_import = described_class.new(import_job)
-      expect(csv_import.preflight_errors).to eq ["No data was detected"]
+      expect(import_job.graph.fatal_errors).to eq ["No data was detected"]
       expect(csv_import).not_to receive(:create_or_update_collection)
       expect(csv_import).not_to receive(:create_or_update_work)
       csv_import.import
@@ -33,11 +33,11 @@ RSpec.describe Tenejo::CsvImporter do
     let(:csv) { fixture_file_upload("./spec/fixtures/csv/fancy.csv") }
     # rubocop:disable RSpec/MessageSpies
     it "returns warnings" do
-      csv_import = described_class.new(import_job)
+      _csv_import = described_class.new(import_job)
       expect(import_job.status).to eq 'submitted'
-      expect(csv_import.preflight_errors).to eq []
-      expect(csv_import.invalid_rows).to include a_hash_including('lineno' => 11)
-      expect(csv_import.preflight_warnings)
+      expect(import_job.graph.fatal_errors).to eq []
+      expect(import_job.graph.invalids).to include a_hash_including('lineno' => 11)
+      expect(import_job.graph.warnings)
         .to contain_exactly(
               "The column \'Comment\' is unknown and will be ignored",
               "Row 2: Resource Type \'Photos\' is not recognized and will be omitted.",


### PR DESCRIPTION
There were a number of methods in the CSV import code that are only used only in tests.

This change moves the test-only logic into the corresponding examples.