### PR TITLE
Add error logging to imports

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -27,7 +27,7 @@ module ApplicationHelper
     users.all.collect { |u| [u.user_key, u.display_name] }
   end
 
-  def status_span_generator(status)
+  def status_span_generator(status, description = nil)
     status_text = status.to_s.titleize
     case status_text
     when 'Submitted'
@@ -44,7 +44,7 @@ module ApplicationHelper
       status_classes = 'status-unrecognized'
       status_text = '-?-'
     end
-    tag.span(status_text, class: 'job-status badge rounded-pill ' + status_classes)
+    tag.span(status_text, class: 'job-status badge rounded-pill ' + status_classes, title: description)
   end
 
   def collection_permission_template_form_for(form:)

--- a/app/lib/tenejo/pf_object.rb
+++ b/app/lib/tenejo/pf_object.rb
@@ -65,7 +65,7 @@ module Tenejo
   class PreFlightObj
     include ActiveModel::Validations
     include ActiveModel::Serializers::JSON
-    attr_accessor :lineno, :children, :visibility, :type, :status
+    attr_accessor :lineno, :children, :visibility, :type, :status, :messages
 
     def warnings
       @warnings ||= Hash.new { |h, k| h[k] = [] }
@@ -110,7 +110,7 @@ module Tenejo
     end
 
     def attributes
-      { lineno: nil, children: [], visibility: nil, warnings: [], type: nil, status: 'not_started' }
+      { lineno: nil, children: [], visibility: nil, warnings: [], type: nil, status: 'not_started', messages: [] }
     end
 
     def initialize(row = {}, lineno = 0, type: self.class.name)
@@ -121,6 +121,7 @@ module Tenejo
         set_attribute(field_name, value, lineno)
       end
       @children = []
+      @messages = []
       @lineno = lineno
       @visibility = transform_visibility
     end

--- a/app/views/jobs/_child.html.erb
+++ b/app/views/jobs/_child.html.erb
@@ -18,7 +18,7 @@
         <% end %>
       </td>
       <td class="item_status">
-        <%= status_span_generator(node.status) %>
+        <%= status_span_generator(node.status, node.messages.join("\n")) %>
       </td>
       <td class="identifier">
         <%= node.identifier %>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -19,5 +19,9 @@ describe ApplicationHelper do
     example "accepts symbols" do
       expect(helper.status_span_generator(:in_progress)).to include "In Progress"
     end
+
+    example "provides hover text" do
+      expect(helper.status_span_generator(:errored, 'something bad happened here')).to include 'title="something bad'
+    end
   end
 end


### PR DESCRIPTION
* Capture any resucued errors during imports
* Log import error messages and stack traces
* Persist error messages to the job graph
* Display error indicators in the job status graph
* Provide the error text via hover-text