### PR TITLE
Capture url download errors during CSV imports

### DIFF
--- a/app/lib/tenejo/csv_importer.rb
+++ b/app/lib/tenejo/csv_importer.rb
@@ -246,7 +246,8 @@ module Tenejo
             file_set.import_url = pffile.file
             file_set.label = pffile.label
             op = Hyrax::Operation.create!
-            ImportUrlJob.perform_now(file_set, op)
+            success = ImportUrlJob.perform_now(file_set, op)
+            raise URI::InvalidURIError, file_set.errors.full_messages.join("\n") unless success
           else
             file_set.label = File.basename(pffile.file)
             local_path = File.join(pffile.import_path, pffile.file)

--- a/spec/lib/tenejo/csv_importer_nesting_spec.rb
+++ b/spec/lib/tenejo/csv_importer_nesting_spec.rb
@@ -88,7 +88,10 @@ RSpec.describe Tenejo::CsvImporter do
 
   it 'sets file import status', :aggregate_failures do
     job = @csv_import.instance_variable_get(:@job)
-    expect(job.graph.files[0].status).to eq "completed"
+    expect(job.graph.files[0].file).to eq "http://"
+    expect(job.graph.files[0].status).to eq "errored"
+    expect(job.graph.files[1].file).to eq "/jokers/Joker1-Recto.tiff"
+    expect(job.graph.files[1].status).to eq "completed"
   end
 
   it 'sets work-level visibility', :aggregate_failures do


### PR DESCRIPTION
This commit adds code to check the completion status of ImportUrlJob and raises an exception that passes any corresponding error messages attached to the associated file_set back to the code responsible for updating the corresponding PFFile object in the job graph.

This permits the error message to be persisted so that we can display it later on the Import job status page.